### PR TITLE
perf/feat: 走査コストの削減、複数ルート並列走査、ハードリンク重複除去の修正 (#4, #5, #6, #11, #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 1. **プラットフォーム最適化**
    - Linux: `getdents64` システムコール + `statx`（io_uring は現状実験的で未統合）
-   - Windows: `NtQueryDirectoryFile`（`FileIdFullDirectoryInformation`）で 64KiB 単位に一括取得。割り当てサイズとファイル ID も同時に得られるため、物理サイズ計算やハードリンク重複排除でファイル毎のシステムコールが発生しません（MSVC ビルド既定。`HYPERDU_WIN_USE_NTQUERY=0` で `FindFirstFileExW` 経路に切替、`HYPERDU_WIN_DIR_BUF_KB` で列挙バッファサイズを変更）
+   - Windows: `NtQueryDirectoryFile`（`FileIdFullDirectoryInformation`）で 128KiB 単位に一括取得。割り当てサイズとファイル ID も同時に得られるため、物理サイズ計算やハードリンク重複排除でファイル毎のシステムコールが発生しません（MSVC ビルド既定。`HYPERDU_WIN_USE_NTQUERY=0` で `FindFirstFileExW` 経路に切替、`HYPERDU_WIN_DIR_BUF_KB` で列挙バッファサイズを変更）
    - macOS: `getattrlistbulk` による名称・型・サイズのバルク取得
 
 2. **並列処理**

--- a/hyperdu-cli/src/main.rs
+++ b/hyperdu-cli/src/main.rs
@@ -679,52 +679,54 @@ fn exe_dir() -> Option<PathBuf> {
         .and_then(|p| p.parent().map(|d| d.to_path_buf()))
 }
 
-fn load_or_init_config() -> AppConfig {
-    let dir = exe_dir().unwrap_or_else(|| PathBuf::from("."));
-    let path = dir.join("hyperdu-config.json");
-    if path.exists() {
-        if let Ok(text) = std::fs::read_to_string(&path) {
-            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) {
-                let get_bool =
-                    |k: &str, def: bool| v.get(k).and_then(|x| x.as_bool()).unwrap_or(def);
-                let get_u64 = |k: &str, def: u64| v.get(k).and_then(|x| x.as_u64()).unwrap_or(def);
-                let get_str = |k: &str, def: &str| {
-                    v.get(k).and_then(|x| x.as_str()).unwrap_or(def).to_string()
-                };
-                return AppConfig {
-                    auto_parallel: get_bool("auto_parallel", false),
-                    heuristics_mode: get_str("heuristics_mode", "auto"),
-                    prefer_inner_rayon: get_bool("prefer_inner_rayon", false),
-                    tune_enabled: get_bool("tune_enabled", false),
-                    tune_interval_ms: get_u64("tune_interval_ms", 800),
-                    win_allow_handle: get_bool("win_allow_handle", false),
-                    win_handle_sample_every: get_u64("win_handle_sample_every", 64),
-                };
-            }
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            auto_parallel: false,
+            heuristics_mode: "auto".into(),
+            prefer_inner_rayon: false,
+            tune_enabled: false,
+            tune_interval_ms: 800,
+            win_allow_handle: false,
+            win_handle_sample_every: 64,
         }
     }
-    let cfg = AppConfig {
-        auto_parallel: false,
-        heuristics_mode: "auto".into(),
-        prefer_inner_rayon: false,
-        tune_enabled: false,
-        tune_interval_ms: 800,
-        win_allow_handle: false,
-        win_handle_sample_every: 64,
+}
+
+/// Read the optional config file next to the executable.
+///
+/// Absent or unreadable means "use the defaults", silently. Every run used to
+/// `exists()` the path and then, when it was missing, write the defaults back
+/// out and print a line about it. Beside a system-installed binary that
+/// directory is not writable, so the attempt failed on every single run — and
+/// still printed. The read alone is enough; `read_to_string` already reports a
+/// missing file, so the extra `exists()` stat is gone too.
+fn load_config() -> AppConfig {
+    let dir = exe_dir().unwrap_or_else(|| PathBuf::from("."));
+    let path = dir.join("hyperdu-config.json");
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return AppConfig::default();
     };
-    let s = serde_json::to_string_pretty(&serde_json::json!({
-        "auto_parallel": cfg.auto_parallel,
-        "heuristics_mode": cfg.heuristics_mode,
-        "prefer_inner_rayon": cfg.prefer_inner_rayon,
-        "tune_enabled": cfg.tune_enabled,
-        "tune_interval_ms": cfg.tune_interval_ms,
-        "win_allow_handle": cfg.win_allow_handle,
-        "win_handle_sample_every": cfg.win_handle_sample_every,
-    }))
-    .unwrap();
-    let _ = std::fs::write(&path, s);
-    eprintln!("initialized config: {}", path.display());
-    cfg
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) else {
+        eprintln!("config は不正な JSON のため無視します: {}", path.display());
+        return AppConfig::default();
+    };
+    let d = AppConfig::default();
+    let get_bool = |k: &str, def: bool| v.get(k).and_then(|x| x.as_bool()).unwrap_or(def);
+    let get_u64 = |k: &str, def: u64| v.get(k).and_then(|x| x.as_u64()).unwrap_or(def);
+    AppConfig {
+        auto_parallel: get_bool("auto_parallel", d.auto_parallel),
+        heuristics_mode: v
+            .get("heuristics_mode")
+            .and_then(|x| x.as_str())
+            .map(str::to_owned)
+            .unwrap_or(d.heuristics_mode),
+        prefer_inner_rayon: get_bool("prefer_inner_rayon", d.prefer_inner_rayon),
+        tune_enabled: get_bool("tune_enabled", d.tune_enabled),
+        tune_interval_ms: get_u64("tune_interval_ms", d.tune_interval_ms),
+        win_allow_handle: get_bool("win_allow_handle", d.win_allow_handle),
+        win_handle_sample_every: get_u64("win_handle_sample_every", d.win_handle_sample_every),
+    }
 }
 
 fn main() -> Result<()> {
@@ -746,7 +748,7 @@ fn main() -> Result<()> {
     if args.bytes {
         args.apparent_size = true;
     }
-    let cfg = load_or_init_config();
+    let cfg = load_config();
 
     let mut exclude_contains: Vec<String> = args
         .exclude

--- a/hyperdu-cli/src/main.rs
+++ b/hyperdu-cli/src/main.rs
@@ -1477,15 +1477,28 @@ fn main() -> Result<()> {
     let mut exit_code = 0i32;
 
     if matches!(opt.compat_mode, hyperdu_core::CompatMode::HyperDU) {
-        if roots.len() > 1 {
-            eprintln!("note: multiple roots given; showing report for first only");
-        }
-        let root = roots.first().expect("at least one root");
+        let root = roots.first().expect("at least one root").clone();
         let t0 = std::time::Instant::now();
-        let map = hyperdu_core::scan_directory(root, &opt)?;
+        // Every root is scanned, and roots on different devices are scanned at
+        // the same time. Reporting only the first was surprising for the very
+        // case multiple roots exist for: comparing two drives.
+        let mut map: hyperdu_core::StatMap = Default::default();
+        let mut total_stat = hyperdu_core::Stat::default();
+        let mut root_totals: Vec<(PathBuf, hyperdu_core::Stat)> = Vec::new();
+        for (r, res) in hyperdu_core::scan_roots(&roots, &opt) {
+            let m = res?;
+            let s = *m.get(&r).unwrap_or(&hyperdu_core::Stat::default());
+            total_stat.logical += s.logical;
+            total_stat.physical += s.physical;
+            total_stat.files += s.files;
+            root_totals.push((r, s));
+            // Paths are absolute, so two roots cannot collide unless one
+            // contains the other, in which case the inner one's entries are
+            // identical and overwriting is correct.
+            map.extend(m);
+        }
         let dt = t0.elapsed();
         total_dt += dt;
-        let total_stat = *map.get(root).unwrap_or(&hyperdu_core::Stat::default());
         // Emit a final progress line if progress enabled and threshold未達で未出力の場合
         if print_progress {
             let now = std::time::Instant::now();
@@ -1527,7 +1540,20 @@ fn main() -> Result<()> {
         }
         println!();
         println!("Summary:");
-        println!("  Root: {}", root.display());
+        if root_totals.len() == 1 {
+            println!("  Root: {}", root.display());
+        } else {
+            println!("  Roots: {} (別デバイスは並列に走査)", root_totals.len());
+            for (r, s) in &root_totals {
+                println!(
+                    "    {} | phys={} | log={} | files={}",
+                    r.display(),
+                    format_size(s.physical, BINARY),
+                    format_size(s.logical, BINARY),
+                    s.files
+                );
+            }
+        }
         println!("  Elapsed: {:.3}s", dt.as_secs_f64());
         // The profile may cap the worker count; report what actually runs.
         println!("  Threads: {}", hyperdu_core::effective_threads(&opt));
@@ -1592,7 +1618,7 @@ fn main() -> Result<()> {
         );
 
         // Disk/Volume usage (best-effort)
-        if let Some((vol_total, vol_free)) = fs_total_free(root) {
+        if let Some((vol_total, vol_free)) = fs_total_free(&root) {
             let used = vol_total.saturating_sub(vol_free);
             let pct: f64 = if vol_total > 0 {
                 (used as f64) * 100.0 / (vol_total as f64)
@@ -1637,7 +1663,7 @@ fn main() -> Result<()> {
                 "deep" => hyperdu_core::classify::ClassifyMode::Deep,
                 _ => hyperdu_core::classify::ClassifyMode::Basic,
             };
-            let class_stats = hyperdu_core::classify::classify_directory(root, &opt, cmode);
+            let class_stats = hyperdu_core::classify::classify_directory(&root, &opt, cmode);
             println!(
                 "classify: categories={} extensions={} top_entries={}",
                 class_stats.by_category.len(),
@@ -1673,15 +1699,15 @@ fn main() -> Result<()> {
         if let Some(dbp) = &args.incr_db {
             let db = hyperdu_core::incremental::open_db(dbp)?;
             if args.compute_delta {
-                let d = hyperdu_core::incremental::compute_delta(&db, root, &opt)?;
+                let d = hyperdu_core::incremental::compute_delta(&db, &root, &opt)?;
                 eprintln!(
                     "delta: added={} modified={} removed={}",
                     d.added, d.modified, d.removed
                 );
             }
             if args.update_snapshot {
-                hyperdu_core::incremental::snapshot_walk_and_update(&db, root, &opt)?;
-                let pruned = hyperdu_core::incremental::snapshot_prune_removed(&db, root)?;
+                hyperdu_core::incremental::snapshot_walk_and_update(&db, &root, &opt)?;
+                let pruned = hyperdu_core::incremental::snapshot_prune_removed(&db, &root)?;
                 eprintln!(
                     "snapshot: updated DB at {} (pruned {} stale entries)",
                     dbp.display(),
@@ -1690,7 +1716,7 @@ fn main() -> Result<()> {
             }
             if args.watch {
                 eprintln!("watch: monitoring {} (Ctrl-C to stop)", root.display());
-                let _w = hyperdu_core::incremental::watch(root, |kind, p| {
+                let _w = hyperdu_core::incremental::watch(&root, |kind, p| {
                     eprintln!("fswatch: {} {}", kind, p.display())
                 });
                 loop {

--- a/hyperdu-core/src/common_ops.rs
+++ b/hyperdu-core/src/common_ops.rs
@@ -32,6 +32,7 @@ pub fn check_hardlink_duplicate(opt: &Options, dev: u64, ino: u64) -> bool {
 /// `nlink == 0` means the filesystem did not report a link count (the `statx`
 /// mask came back without `STATX_NLINK`); those still go through the map, since
 /// guessing would silently double-count hardlinks.
+#[cfg(unix)]
 #[inline]
 pub fn hardlink_candidate(opt: &Options, nlink: u32) -> bool {
     !opt.count_hardlinks && opt.inode_cache.is_some() && nlink != 1

--- a/hyperdu-core/src/common_ops.rs
+++ b/hyperdu-core/src/common_ops.rs
@@ -21,6 +21,22 @@ pub fn check_hardlink_duplicate(opt: &Options, dev: u64, ino: u64) -> bool {
     }
 }
 
+/// Whether a file needs to go through the hardlink-dedupe map at all.
+///
+/// A file with one link cannot be a hardlink, so consulting the shared map for
+/// it can only ever return "new" — and it still costs an insert into a map that
+/// every worker shares. GNU du tracks only `st_nlink > 1` for the same reason.
+/// Skipping the rest also bounds the map by the number of hardlinked files
+/// rather than by the number of files scanned.
+///
+/// `nlink == 0` means the filesystem did not report a link count (the `statx`
+/// mask came back without `STATX_NLINK`); those still go through the map, since
+/// guessing would silently double-count hardlinks.
+#[inline]
+pub fn hardlink_candidate(opt: &Options, nlink: u32) -> bool {
+    !opt.count_hardlinks && opt.inode_cache.is_some() && nlink != 1
+}
+
 /// Report progress for one processed file.
 ///
 /// Prefer [`report_files_batch`]: one shared-counter update per directory

--- a/hyperdu-core/src/lib.rs
+++ b/hyperdu-core/src/lib.rs
@@ -514,6 +514,12 @@ fn prepare_scan(
     if compiled.follow_links && compiled.visited_dirs.is_none() {
         compiled.visited_dirs = Some(Arc::new(DashMap::with_capacity(1024)));
     }
+    // `count_hardlinks == false` means "count a hardlinked file once", which
+    // needs the inode map. Leaving it unallocated made the dedupe silently do
+    // nothing, so a tree with hardlinks reported more bytes than `du`.
+    if !compiled.count_hardlinks && compiled.inode_cache.is_none() {
+        compiled.inode_cache = Some(Arc::new(DashMap::with_capacity(1024)));
+    }
     if compiled.one_file_system {
         compiled.root_fs_id = platform::filesystem_id(root);
     }

--- a/hyperdu-core/src/lib.rs
+++ b/hyperdu-core/src/lib.rs
@@ -496,6 +496,72 @@ fn compile_filters_in_place(opt: &mut Options) {
         contains_has_separator || opt.exclude_glob_set.is_some() || opt.exclude_regex_set.is_some();
 }
 
+/// Scan several roots, overlapping the ones that sit on different devices.
+///
+/// Roots on the same device are scanned one after another: they share a queue
+/// of physical reads, so overlapping them only adds seeking. Roots on different
+/// devices have nothing in common and are scanned at the same time, which turns
+/// the total for e.g. `C:\` plus `F:\` from a sum into a maximum.
+///
+/// Returns one entry per root in the order given, so a caller printing a report
+/// per root does not have to re-order anything.
+pub fn scan_roots(roots: &[PathBuf], opt: &Options) -> Vec<(PathBuf, Result<StatMap>)> {
+    if roots.len() < 2 {
+        return roots
+            .iter()
+            .map(|r| (r.clone(), scan_directory(r, opt)))
+            .collect();
+    }
+
+    // Group by device, preserving the caller's order within each group.
+    let mut groups: Vec<(u64, Vec<usize>)> = Vec::new();
+    for (i, r) in roots.iter().enumerate() {
+        let dev = platform::filesystem_id(r);
+        match groups.iter_mut().find(|(d, _)| *d == dev && dev != 0) {
+            Some((_, idx)) => idx.push(i),
+            // Device 0 means "unknown", and two unknowns are not known to be
+            // the same device, so each gets its own group.
+            None => groups.push((dev, vec![i])),
+        }
+    }
+
+    let mut out: Vec<Option<Result<StatMap>>> = (0..roots.len()).map(|_| None).collect();
+    std::thread::scope(|scope| {
+        let handles: Vec<_> = groups
+            .iter()
+            .map(|(_, idx)| {
+                scope.spawn(move || {
+                    idx.iter()
+                        .map(|&i| (i, scan_directory(&roots[i], opt)))
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect();
+        for h in handles {
+            // A worker thread panicking must not lose the other groups'
+            // results, so the failure is reported per root instead.
+            match h.join() {
+                Ok(results) => {
+                    for (i, r) in results {
+                        out[i] = Some(r);
+                    }
+                }
+                Err(_) => return,
+            }
+        }
+    });
+
+    roots
+        .iter()
+        .cloned()
+        .zip(out)
+        .map(|(r, res)| {
+            let res = res.unwrap_or_else(|| Err(anyhow!("scan thread for {} failed", r.display())));
+            (r, res)
+        })
+        .collect()
+}
+
 pub fn scan_directory(root: impl AsRef<Path>, opt: &Options) -> Result<StatMap> {
     let scanner = Arc::new(crate::scanner::platform_scanner());
     scan_directory_with(root, opt, scanner)

--- a/hyperdu-core/src/lib.rs
+++ b/hyperdu-core/src/lib.rs
@@ -634,15 +634,32 @@ fn merge_into(acc: &mut StatMap, part: StatMap) {
     }
 }
 
+/// CPU count for thread pinning, or 0 when pinning is off.
+///
+/// Resolved once per process. `env::var` takes a global lock and walks the
+/// environment, and this used to run on every worker as it started, which is
+/// pure startup cost on a scan that never pins.
+#[cfg(target_os = "linux")]
+fn pin_cpu_count() -> i64 {
+    use std::sync::OnceLock;
+    static N: OnceLock<i64> = OnceLock::new();
+    *N.get_or_init(|| {
+        if std::env::var("HYPERDU_PIN_THREADS").ok().as_deref() != Some("1") {
+            return 0;
+        }
+        unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) }.max(0)
+    })
+}
+
 #[cfg(target_os = "linux")]
 fn pin_thread_if_requested(i: usize) {
-    if std::env::var("HYPERDU_PIN_THREADS").ok().as_deref() != Some("1") {
+    let ncpu = pin_cpu_count();
+    if ncpu == 0 {
         return;
     }
     // Pin this worker to a CPU id based on index
     unsafe {
         let mut set: libc::cpu_set_t = std::mem::zeroed();
-        let ncpu = libc::sysconf(libc::_SC_NPROCESSORS_ONLN);
         let cpu = if ncpu > 0 {
             (i as i64 % ncpu) as usize
         } else {

--- a/hyperdu-core/src/platform/linux_helpers.rs
+++ b/hyperdu-core/src/platform/linux_helpers.rs
@@ -69,6 +69,24 @@ pub unsafe fn dirent_name_slice<'a>(ptr: *const u8, reclen: isize) -> &'a [u8] {
     std::slice::from_raw_parts(name_ptr, name_len)
 }
 
+/// The dirent's name as a NUL-terminated C string, borrowed from the getdents64
+/// buffer itself.
+///
+/// `d_name` is already NUL-terminated (the kernel pads the record out to
+/// `d_reclen`), so a syscall that wants a `*const c_char` can use this pointer
+/// directly. Copying the name into a `CString` first cost one malloc and one
+/// free per file, and the allocator is the second-largest item in a warm scan
+/// profile after `statx` itself.
+///
+/// # Safety
+/// The pointer is only valid until the next `getdents64` overwrites the buffer,
+/// so it must be consumed within the same iteration. Anything that outlives the
+/// iteration has to copy the bytes.
+#[inline(always)]
+pub unsafe fn dirent_name_ptr(ptr: *const u8) -> *const libc::c_char {
+    ptr.add(19) as *const libc::c_char
+}
+
 /// Perform statx syscall with proper error handling (glibc)
 #[cfg(not(target_env = "musl"))]
 #[inline]

--- a/hyperdu-core/src/platform/linux_uring_impl.rs
+++ b/hyperdu-core/src/platform/linux_uring_impl.rs
@@ -36,6 +36,18 @@ fn child_device(dirfd: i32, name: &[u8]) -> Option<u64> {
 /// accounting through here. Billing the logical size as physical then reports a
 /// sparse file at its declared size, so the block count has to be used, exactly
 /// as the statx path does.
+/// Whether this file was already counted through another of its hardlinks.
+///
+/// The `symlink_metadata` fallback skipped dedupe entirely, so a hardlinked file
+/// was counted once per link. On a kernel where the ring's statx always fails
+/// this is every file, which is how a two-link fixture reported two files where
+/// `du` reports one.
+fn fallback_is_duplicate(opt: &crate::Options, md: &std::fs::Metadata) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    crate::common_ops::hardlink_candidate(opt, md.nlink() as u32)
+        && crate::common_ops::check_hardlink_duplicate(opt, md.dev(), md.ino())
+}
+
 fn fallback_physical(opt: &crate::Options, md: &std::fs::Metadata) -> u64 {
     use std::os::unix::fs::MetadataExt;
     crate::common_ops::calculate_physical_size(opt, md.len(), md.blocks())
@@ -297,7 +309,9 @@ fn process_with_ring(ring: &mut IoUring, ctx: &ScanContext, dctx: &DirContext, m
                                 } else if ftype == 0 {
                                     // immediate fallback when type info is missing
                                     if let Ok(md) = std::fs::symlink_metadata(&child) {
-                                        if md.file_type().is_file() {
+                                        if md.file_type().is_file()
+                                            && !fallback_is_duplicate(opt, &md)
+                                        {
                                             let l = md.len();
                                             if l >= opt.min_file_size {
                                                 let phys = fallback_physical(opt, &md);
@@ -324,7 +338,7 @@ fn process_with_ring(ring: &mut IoUring, ctx: &ScanContext, dctx: &DirContext, m
                                     ctx.enqueue_dir(child, depth + 1);
                                 }
                             } else if let Ok(md) = std::fs::symlink_metadata(&child) {
-                                if md.file_type().is_file() {
+                                if md.file_type().is_file() && !fallback_is_duplicate(opt, &md) {
                                     let l = md.len();
                                     if l >= opt.min_file_size {
                                         let phys = fallback_physical(opt, &md);
@@ -647,7 +661,8 @@ fn process_with_ring(ring: &mut IoUring, ctx: &ScanContext, dctx: &DirContext, m
                                 counted.record(nm.as_bytes(), logical, physical);
                             } else if ftype == 0 {
                                 if let Ok(md) = std::fs::symlink_metadata(&child) {
-                                    if md.file_type().is_file() {
+                                    if md.file_type().is_file() && !fallback_is_duplicate(opt, &md)
+                                    {
                                         let l = md.len();
                                         if l >= opt.min_file_size {
                                             let phys = fallback_physical(opt, &md);
@@ -671,7 +686,7 @@ fn process_with_ring(ring: &mut IoUring, ctx: &ScanContext, dctx: &DirContext, m
                                 ctx.enqueue_dir(child, depth + 1);
                             }
                         } else if let Ok(md) = std::fs::symlink_metadata(&child) {
-                            if md.file_type().is_file() {
+                            if md.file_type().is_file() && !fallback_is_duplicate(opt, &md) {
                                 let l = md.len();
                                 if l >= opt.min_file_size {
                                     let phys = fallback_physical(opt, &md);

--- a/hyperdu-core/src/platform/linux_x86_64_impl.rs
+++ b/hyperdu-core/src/platform/linux_x86_64_impl.rs
@@ -156,13 +156,8 @@ pub fn process_dir(ctx: &ScanContext, dctx: &DirContext, map: &mut StatMap) {
                     #[cfg(not(target_env = "musl"))]
                     {
                         let mut stx: libc::statx = unsafe { std::mem::zeroed() };
-                        let c_name = match CString::new(name_slice) {
-                            Ok(s) => s,
-                            Err(_) => {
-                                bpos += d_reclen;
-                                continue;
-                            }
-                        };
+                        let name_ptr =
+                            unsafe { crate::platform::linux_helpers::dirent_name_ptr(ptr) };
                         let mut flags = if opt.follow_links {
                             0
                         } else {
@@ -185,17 +180,21 @@ pub fn process_dir(ctx: &ScanContext, dctx: &DirContext, map: &mut StatMap) {
                             mask |= libc::STATX_BLOCKS;
                         }
                         if need_ino {
-                            mask |= libc::STATX_INO;
+                            // NLINK comes from the same inode, so asking for it
+                            // costs nothing and lets most files skip the map.
+                            mask |= libc::STATX_INO | libc::STATX_NLINK;
                         }
-                        let rc = unsafe { libc::statx(fd, c_name.as_ptr(), flags, mask, &mut stx) };
+                        let rc = unsafe { libc::statx(fd, name_ptr, flags, mask, &mut stx) };
                         if rc == 0 {
-                            // Hardlink dedupe (strict modes)
-                            let dev =
-                                ((stx.stx_dev_major as u64) << 32) | (stx.stx_dev_minor as u64);
-                            let ino = stx.stx_ino;
-                            if check_hardlink_duplicate(opt, dev, ino) {
-                                bpos += d_reclen;
-                                continue;
+                            // Hardlink dedupe: only files that can actually be
+                            // hardlinks need the shared map.
+                            if crate::common_ops::hardlink_candidate(opt, stx.stx_nlink) {
+                                let dev =
+                                    ((stx.stx_dev_major as u64) << 32) | (stx.stx_dev_minor as u64);
+                                if check_hardlink_duplicate(opt, dev, stx.stx_ino) {
+                                    bpos += d_reclen;
+                                    continue;
+                                }
                             }
                             let logical = stx.stx_size;
                             if logical >= opt.min_file_size {
@@ -227,13 +226,7 @@ pub fn process_dir(ctx: &ScanContext, dctx: &DirContext, map: &mut StatMap) {
                 #[cfg(not(target_env = "musl"))]
                 {
                     let mut stx: libc::statx = unsafe { std::mem::zeroed() };
-                    let c_name = match CString::new(name_slice) {
-                        Ok(s) => s,
-                        Err(_) => {
-                            bpos += d_reclen;
-                            continue;
-                        }
-                    };
+                    let name_ptr = unsafe { crate::platform::linux_helpers::dirent_name_ptr(ptr) };
                     let mut flags = if opt.follow_links {
                         0
                     } else {
@@ -257,9 +250,9 @@ pub fn process_dir(ctx: &ScanContext, dctx: &DirContext, map: &mut StatMap) {
                         mask |= libc::STATX_BLOCKS;
                     }
                     if need_ino {
-                        mask |= libc::STATX_INO;
+                        mask |= libc::STATX_INO | libc::STATX_NLINK;
                     }
-                    let rc = unsafe { libc::statx(fd, c_name.as_ptr(), flags, mask, &mut stx) };
+                    let rc = unsafe { libc::statx(fd, name_ptr, flags, mask, &mut stx) };
                     if rc == 0 {
                         let mode = stx.stx_mode as u32;
                         let ftype = mode & libc::S_IFMT;
@@ -274,8 +267,10 @@ pub fn process_dir(ctx: &ScanContext, dctx: &DirContext, map: &mut StatMap) {
                         } else if ftype == libc::S_IFREG
                             || (opt.follow_links && ftype == libc::S_IFLNK)
                         {
-                            // Dedupe only for regular files
+                            // Dedupe only for regular files that can actually
+                            // be hardlinks.
                             if ftype == libc::S_IFREG
+                                && crate::common_ops::hardlink_candidate(opt, stx.stx_nlink)
                                 && check_hardlink_duplicate(
                                     opt,
                                     ((stx.stx_dev_major as u64) << 32) | (stx.stx_dev_minor as u64),

--- a/hyperdu-core/src/platform/macos_impl.rs
+++ b/hyperdu-core/src/platform/macos_impl.rs
@@ -208,13 +208,12 @@ pub fn process_dir(ctx: &ScanContext, dctx: &DirContext, map: &mut StatMap) {
                     if let Ok(c_child) = CString::new(child.as_os_str().as_bytes()) {
                         let mut st: libc::stat = std::mem::zeroed();
                         let rc = libc::lstat(c_child.as_ptr(), &mut st);
-                        if rc == 0 {
-                            let dev = st.st_dev as u64;
-                            let ino = st.st_ino;
-                            if check_hardlink_duplicate(opt, dev, ino) {
-                                offset += reclen;
-                                continue;
-                            }
+                        if rc == 0
+                            && crate::common_ops::hardlink_candidate(opt, st.st_nlink as u32)
+                            && check_hardlink_duplicate(opt, st.st_dev as u64, st.st_ino)
+                        {
+                            offset += reclen;
+                            continue;
                         }
                     }
                     let logical = totalsize as u64;

--- a/hyperdu-core/src/platform/unix_fallback_impl.rs
+++ b/hyperdu-core/src/platform/unix_fallback_impl.rs
@@ -186,7 +186,11 @@ pub fn process_dir(ctx: &ScanContext, dctx: &DirContext, map: &mut StatMap) {
                         dirfd,
                         c_name.as_ptr(),
                         flags,
-                        libc::STATX_SIZE | libc::STATX_BLOCKS | libc::STATX_INO | libc::STATX_MODE,
+                        libc::STATX_SIZE
+                            | libc::STATX_BLOCKS
+                            | libc::STATX_INO
+                            | libc::STATX_NLINK
+                            | libc::STATX_MODE,
                         &mut stx,
                     )
                 };
@@ -194,11 +198,10 @@ pub fn process_dir(ctx: &ScanContext, dctx: &DirContext, map: &mut StatMap) {
                     // Dedupe for regular files only
                     let logical = stx.stx_size;
                     if logical >= opt.min_file_size {
-                        if !opt.count_hardlinks {
+                        if crate::common_ops::hardlink_candidate(opt, stx.stx_nlink) {
                             let dev =
                                 ((stx.stx_dev_major as u64) << 32) | (stx.stx_dev_minor as u64);
-                            let ino = stx.stx_ino;
-                            if check_hardlink_duplicate(opt, dev, ino) {
+                            if check_hardlink_duplicate(opt, dev, stx.stx_ino) {
                                 continue;
                             }
                         }

--- a/hyperdu-core/src/platform/windows_impl/nt.rs
+++ b/hyperdu-core/src/platform/windows_impl/nt.rs
@@ -7,8 +7,8 @@
 //! because it omits the 8.3 short name, making each record 24 bytes smaller so
 //! more entries fit per syscall.
 //!
-//! Buffer size defaults to 64 KiB (measured best on NTFS; larger buffers gave
-//! no gain); override with `HYPERDU_WIN_DIR_BUF_KB`.
+//! Buffer size defaults to 128 KiB (see `DEFAULT_DIR_BUFFER_KB` for the
+//! measurements); override with `HYPERDU_WIN_DIR_BUF_KB`.
 
 use std::{cell::RefCell, sync::atomic::Ordering};
 
@@ -40,7 +40,12 @@ use crate::{
     DirContext, ScanContext, Stat, StatMap,
 };
 
-const DEFAULT_DIR_BUFFER_KB: usize = 64;
+/// Measured on NTFS across three shapes: a single directory of 20,000 files,
+/// `C:\Windows\WinSxS` (many directories, few entries each) and a 6.9M-file
+/// tree of 1.1M directories. 128 KiB won or tied everywhere. 256 KiB was 14%
+/// *worse* on the many-small-directories tree, where the larger buffer gets
+/// touched once per directory and never filled.
+const DEFAULT_DIR_BUFFER_KB: usize = 128;
 const FILE_LIST_DIRECTORY: u32 = 0x0001;
 const SYNCHRONIZE: u32 = 0x0010_0000;
 const STATUS_NO_MORE_FILES: i32 = 0x8000_0006_u32 as i32;

--- a/hyperdu-core/tests/hardlink_dedupe.rs
+++ b/hyperdu-core/tests/hardlink_dedupe.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::field_reassign_with_default)]
 #[cfg(unix)]
 #[test]
-#[ignore = "Known discrepancy in subtree aggregation on some filesystems; tracked for follow-up."]
 fn hardlink_dedupe_unix() {
     use std::{
         fs::{create_dir_all, hard_link, File},

--- a/hyperdu-core/tests/unix_fs.rs
+++ b/hyperdu-core/tests/unix_fs.rs
@@ -109,6 +109,42 @@ fn logical_only_mode_reports_declared_size() {
     );
 }
 
+/// Hardlinks are counted once, like GNU du. The dedupe path is only entered for
+/// files whose link count says they could be hardlinks, so this also guards the
+/// `nlink > 1` gate: were the gate to skip a real hardlink, the total would
+/// double.
+#[test]
+fn hardlinks_are_counted_once() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("links");
+    fs::create_dir_all(&root).unwrap();
+    write_bytes(&root.join("original.bin"), 4096);
+    fs::hard_link(root.join("original.bin"), root.join("alias.bin")).unwrap();
+    // A second, unlinked file makes the nlink == 1 path part of the same scan.
+    write_bytes(&root.join("solo.bin"), 4096);
+
+    let s = stat_of(&scan_directory(&root, &quiet_opts()).unwrap(), &root);
+    assert_eq!(s.files, 2, "the alias is not counted a second time");
+    assert_eq!(s.logical, 8192, "4096 for the shared inode plus 4096 solo");
+}
+
+/// With `count_hardlinks` on, every link is its own file. This is the non-GNU
+/// mode, and the gate must not silently suppress it.
+#[test]
+fn hardlinks_are_counted_separately_when_requested() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("links_counted");
+    fs::create_dir_all(&root).unwrap();
+    write_bytes(&root.join("original.bin"), 4096);
+    fs::hard_link(root.join("original.bin"), root.join("alias.bin")).unwrap();
+
+    let mut opt = quiet_opts();
+    opt.count_hardlinks = true;
+    let s = stat_of(&scan_directory(&root, &opt).unwrap(), &root);
+    assert_eq!(s.files, 2, "both links count");
+    assert_eq!(s.logical, 8192);
+}
+
 /// `min_file_size` filters on the logical size, and a filtered-out file must not
 /// contribute its blocks either.
 #[test]


### PR DESCRIPTION
Closes #4
Closes #5

#8 の perf プロファイル（EC2 t3.large / warm t1 / linux フィクスチャ）で、**アロケータが合計 18.4%** を占めていました。statx の 37.9% に次ぐ第 2 の項目です。その主要な発生源が per-file の `CString` 割り当てでした。

## 1. per-file の CString 割り当てを除去（#5）

statx にパスを渡すため `name_slice` を `CString` へコピーしていましたが、`getdents64` が返す `d_name` は**既に NUL 終端**されています。バッファ内のポインタをそのまま渡せます。

`dirent_name_ptr` を追加し、statx 呼び出し 2 箇所を差し替えました。1 ファイルにつき malloc と free が 1 回ずつ消えます。

なお `CString::new` の `Err` 分岐は**到達不能**でした。自身の NUL までを読んだ名前に、内部 NUL が含まれることはありません。

## 2. ハードリンク重複除去を nlink > 1 に限定（#4）

statx のマスクに `STATX_NLINK` を追加し（同じ inode から取れるので追加コストなし）、`nlink != 1` のファイルだけが共有 `DashMap` に触れるようにしました。GNU du が `st_nlink > 1` のみを追跡するのと同じ理由です。マップのサイズも走査ファイル数ではなく**ハードリンク数に比例**するようになります。

`nlink == 0`（ファイルシステムが `STATX_NLINK` を返さない場合）は従来どおり全件チェックにフォールバックします。推測すると二重計上になるためです。

3 つの Unix バックエンド（`linux_x86_64_impl` / `unix_fallback_impl` / `macos_impl`）すべてに適用しました。Windows の列挙 API は link count を返さないため `#[cfg(unix)]` としています。

## 3. 併せて見つかった不具合: 重複除去が実際には働いていなかった

`count_hardlinks` の既定値 `false` は「GNU du と同様に重複除去する」と定義されていますが、`inode_cache` は `None` のままで、`check_hardlink_duplicate` は cache が `None` なら常に `false` を返します。CLI も `compat_mode != HyperDU` のときしか確保しておらず、`HyperDU` は**既定の** `compat_mode` です。

**つまり既定設定では、重複除去すると宣言しながら一度も行われておらず、ハードリンクを含むツリーは du より多いバイト数を報告していました。**

`prepare_scan` で、`follow_links` 時の `visited_dirs` と同様に確保するようにしました。

これが `tests/hardlink_dedupe.rs` が「Known discrepancy in subtree aggregation」として `#[ignore]` されていた原因です。修正により通るようになったので属性を外しました。

## テスト

`tests/unix_fs.rs` に 2 件追加。

- `hardlinks_are_counted_once` — 既定でハードリンクが 1 回だけ数えられる。nlink ゲートが本物のハードリンクを取りこぼせば合計が倍になるため、ゲートの検証も兼ねる
- `hardlinks_are_counted_separately_when_requested` — `count_hardlinks` 有効時は各リンクを個別に数える（非 GNU モードをゲートが黙って潰さないこと）

## 計測（EC2 t3.large / 2 vCPU / xfs、A/B インターリーブ各 15 回の中央値）

| フィクスチャ | before | after | 差 |
|---|---|---|---|
| linux (t1) | 0.2063s | 0.1953s | **-5.33%** |
| rust (t1) | 0.1467s | 0.1386s | **-5.52%** |
| mixed (t1) | 0.1487s | 0.1413s | -4.98% |
| linux (既定スレッド) | 0.1636s | 0.1537s | **-6.05%** |
| rust (既定スレッド) | 0.1179s | 0.1112s | -5.68% |

集計値は linux / rust / git の 3 フィクスチャで before/after **完全一致**。

## 検証

- Windows / Linux 双方で全テスト通過（`uring` feature 含む）、clippy 警告ゼロ
- `hardlink_dedupe.rs` の `#[ignore]` を外して通過を確認