### PR TITLE
chore/docs: 計測規約をスクリプトに組み込み、README の性能表を実測値にする (#17, #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 **HyperDU** は、高速なディスク使用量分析を目指した Rust 製ツールです。並列処理とOS固有APIの最適化により、従来のツールより高速に動作する可能性があります。
 
-> **⚠️ 動作確認について**: 現在 Windows 環境でのみ動作確認済みです。Linux/macOS での動作は未確認のため、これらの環境では動作しない可能性があります。
+> **⚠️ 動作確認について**: Windows と Linux は実機で検証済みです（CI でも両方をテストしています）。macOS はビルドのみで実機検証していません。
 
 ## 🚀 特徴
 
 - **高速スキャン**: 並列処理とプラットフォーム最適化による高速化を目指しています
 - **du 互換モード**: `--compat gnu` オプションで GNU du 風の出力形式に対応
-- **マルチプラットフォーム対応予定**: Windows (動作確認済み), Linux (未確認), macOS (未確認)
+- **マルチプラットフォーム対応**: Windows (検証済み), Linux (検証済み), macOS (実機未検証)
 - **並列処理**: ワークスティーリングアルゴリズムによる効率的な並列化
 - **プラットフォーム最適化**:
   - Linux: `getdents64` システムコール + `statx`
@@ -82,8 +82,8 @@ cargo install --path hyperdu-gui  # GUI版（オプション）
 
 - Rust 1.75 以降
 - **Windows**: Visual Studio 2019 以降または MinGW-w64 (動作確認済み)
-- **Linux**: 未確認
-- **macOS**: 未確認
+- **Linux**: 検証済み（Amazon Linux 2023 / xfs、WSL2 / ext4）
+- **macOS**: 実機未検証
 
 ## 🎯 使い方
 
@@ -201,19 +201,35 @@ hyperdu-gui ~/Documents
 - ディレクトリのドリルダウン
 - 結果のエクスポート
 
-## 🔥 パフォーマンス目標
+## 🔥 パフォーマンス
 
-### 期待される性能向上
+数値はすべて `scripts/bench_du.sh` による実測です。同スクリプトは、古いバイナリを測ろうとした場合と、両ツールが同じファイル集合を走査していない場合に**エラーで停止**します。
 
-高速化を目指していますが、実際の性能はストレージ種類、ファイルシステム、ファイル構成に大きく依存します。
+### GNU du 8.32 との比較（EC2 t3.large / xfs / kernel 6.1）
 
-| 想定環境 | 期待される改善 |
-|---------|---------------|
-| NVMe SSD (多数の小ファイル) | 大幅な高速化の可能性 |
-| HDD (大規模ディレクトリ) | 中程度の高速化 |
-| ネットワークドライブ | 環境依存 |
+| ツリー | files | dirs | warm | cold |
+|---|---|---|---|---|
+| Linux カーネル | 95,953 | 6,299 | 1.32x | **4.93x** |
+| rust リポジトリ | 62,621 | 4,734 | 1.36x | **5.56x** |
+| git リポジトリ | 4,874 | 242 | 1.00x | 2.02x |
 
-> **注**: 上記は理論値であり、実環境での性能は異なる場合があります。Windows 環境でのみ動作確認済みです。
+warm は 5 回の最小値、cold は 3 回の burn-in 後に両ツールを交互実行した 5 組の中央値です。ファイル数は 3 つとも `find` と完全一致しています。
+
+### warm の比は物理コア数の関数です
+
+**du は単一スレッド**なので、比は走査対象よりも物理コア数で決まります。上表の t3.large は **2 vCPU = 物理 1 コア + SMT** で、並列化の余地がほぼありません。参考までに WSL2（物理 8 コア / 16 スレッド、ext4）では同じ rust ツリーで **7.18x** です。
+
+**cold こそが実用上の主戦場**です。ディスク使用量の調査は通常 1 回きりで、ページキャッシュは温まっていません。
+
+### Windows
+
+`NtQueryDirectoryFile` + `FileIdFullDirectoryInformation` への変更により、旧実装比 **4.7x**。1 回の列挙でサイズ・割り当てサイズ・ファイル ID が同時に得られるため、ファイルごとのハンドル open が不要です。
+
+### なぜ Linux は Windows より差が小さいのか
+
+構造的な理由があります。`struct dirent64` は `d_ino` / `d_off` / `d_reclen` / `d_type` / `d_name` の 5 フィールド固定で、**サイズを入れる場所がありません**。さらに VFS の `dir_emit()` / `filldir64()` のコールバック署名が `(name, namelen, ino, dtype)` しか受け取らないため、どのファイルシステムであれ列挙時にサイズを返せません。
+
+したがって Linux では**ファイル 1 個につき `statx` が 1 回**必要で、syscall 数はファイル数に比例します（Windows はディレクトリ数に比例）。GNU du も同じ制約下にあるため、warm では両者が同じ壁に当たります。
 
 ### du 互換モードでの動作確認
 
@@ -325,18 +341,31 @@ cargo clippy --workspace -- -D warnings
 
 ### ベンチと回帰基準
 
-高速化/回帰検知のために簡易ベンチスクリプトを用意しています。
+**GNU du との比較には `scripts/bench_du.sh` を使ってください。** 公平性の条件をスクリプト側で強制します。
 
 ```
-# 代表ディレクトリで比較（デフォルト3回平均）
+# warm のみ
+scripts/bench_du.sh /path/to/tree
+
+# cold も測る（drop_caches のため root/sudo が必要）
+scripts/bench_du.sh --cold /path/to/tree1 /path/to/tree2
+```
+
+このスクリプトは以下を**自動で検出して停止**します。いずれも過去に実際にやらかした失敗です。
+
+| 検出 | 背景 |
+|---|---|
+| **古いバイナリ** | `cargo build --features X` が `target/release` を上書きし、後の計測が古いバイナリを測っていた |
+| **走査対象の不一致** | 既定除外の `.git` が `.github` に部分一致し、HyperDU だけ 437 ディレクトリ少なく走査していた。`find` のファイル数と突き合わせる |
+| **cold の最小値** | EBS gp3 のバースト枯渇で同一条件が 0.495s → 0.88s と 1.8 倍ぶれる。最小値はバースト状態だけを拾うため、burn-in → 交互実行 → **中央値**とする |
+
+ヘッダには commit、未コミット変更の有無、物理コア数、ファイルシステム種別、カーネルを出力します。後から「どの条件の数字か」を復元できるようにするためです。
+
+HyperDU の変種間（rayon-par など）の比較には `scripts/bench.sh` を使います。
+
+```
 scripts/bench.sh --root /path/to/dir
-
-# rayon-par（自動並列）ビルドも測定
 WITH_RAYON=1 scripts/bench.sh --root /path/to/dir
-
-
-# 分類・インクリメンタルの測定
-scripts/bench.sh --root /path/to/dir   # classify-basic / classify-deep / incr-update / incr-delta を含む
 ```
 
 回帰基準（目安）
@@ -380,9 +409,9 @@ scripts/bench.sh --root /path/to/dir   # classify-basic / classify-deep / incr-u
 ## ⚠️ 既知の問題と制限事項
 
 ### 動作環境
-- **Windows**: 動作確認済み
-- **Linux**: 未確認（ビルドは可能だが動作未検証）
-- **macOS**: 未確認（ビルドは可能だが動作未検証）
+- **Windows**: 検証済み（NTFS、CI あり）
+- **Linux**: 検証済み（Amazon Linux 2023 / xfs、WSL2 / ext4、CI あり）
+- **macOS**: 実機未検証（ビルドは可能）
 
 ### その他の問題
 - WSL環境: `/mnt/*` (NTFS) でビルド時に一時ディレクトリ削除エラーが出る場合があります。Linux側にリポジトリを配置するか、`CARGO_TARGET_DIR` を設定してください

--- a/scripts/bench_du.sh
+++ b/scripts/bench_du.sh
@@ -4,32 +4,47 @@ set -uo pipefail
 # Compare hyperdu against GNU du on the same trees.
 #
 # Usage:
-#   scripts/bench_du.sh [--bin PATH] [--runs N] [--cold] TREE [TREE...]
+#   scripts/bench_du.sh [--bin PATH] [--runs N] [--cold] [--allow-stale] TREE [TREE...]
 #
 # Options:
-#   --bin PATH   hyperdu-cli binary (default: target/release/hyperdu-cli)
-#   --runs N     Warm iterations per case, minimum reported (default: 5)
-#   --cold       Also measure with a cold page cache. Needs root, since it
-#                writes to /proc/sys/vm/drop_caches between runs.
-#   -h, --help   Show this help
+#   --bin PATH      hyperdu-cli binary (default: target/release/hyperdu-cli)
+#   --runs N        Warm iterations per case (default: 5)
+#   --cold          Also measure with a cold page cache. Needs root, since it
+#                   writes to /proc/sys/vm/drop_caches between runs.
+#   --allow-stale   Skip the check that the binary is newer than the sources.
+#                   Only for measuring a deliberately older build.
+#   -h, --help      Show this help
 #
-# Fairness notes, all of which matter more than they look:
-#   - Both tools get `-x` / `--one-file-system`. A tree that hides a different
-#     mount (say /usr/lib/wsl/drivers on WSL2) is otherwise scanned by one tool
-#     and skipped by the other, which silently invalidates the comparison.
-#   - hyperdu is given `--exclude ""` so its default skip list (.git,
-#     node_modules, target) does not shrink its workload.
-#   - The minimum of N runs is reported. Single runs on a busy machine vary by
-#     2-4x and will tell you whatever you want to hear.
-#   - The totals differ by design: du counts the blocks of directories
-#     themselves, hyperdu counts file data. `--compat gnu -b` matches GNU
-#     byte-for-byte on file data; see README.
+# This script enforces the fairness rules rather than documenting them, because
+# every one of them has already been violated at least once:
+#
+#   - STALE BINARY. `cargo build --features X` overwrites target/release, so a
+#     later run measured an older binary and reported the wrong numbers. The
+#     binary is now compared against the newest source mtime and the run aborts.
+#   - EQUAL WORKLOAD. hyperdu's default exclude list once dropped .github (".git"
+#     matched it as a substring), so it scanned 437 fewer directories than du and
+#     looked faster for it. Each tree's file count is now checked against find
+#     and the run aborts on a mismatch.
+#   - COLD IS NOT A MINIMUM. On EBS gp3 the same cold run measured 0.495s twice
+#     and then 0.81-0.89s six times as the volume's burst credit ran out. Taking
+#     the minimum reports the burst state as if it were steady state. Cold runs
+#     therefore burn the burst off first, interleave the two tools, and report
+#     the median. Warm runs stay on the minimum: they measured within +/-1.5%
+#     across 25 repetitions, so the minimum is representative there.
+#   - BOTH TOOLS GET `-x`. A tree hiding a different mount (say
+#     /usr/lib/wsl/drivers on WSL2) is otherwise scanned by one tool and skipped
+#     by the other.
+#
+# The totals still differ by design: du counts the blocks of directories
+# themselves, hyperdu counts file data. `--compat gnu -b` matches GNU
+# byte-for-byte on file data; see README.
 
-usage() { awk 'NR<=32 && /^#( |$)/ { sub(/^# ?/, ""); print }' "$0"; }
+usage() { awk 'NR<=41 && /^#( |$)/ { sub(/^# ?/, ""); print }' "$0"; }
 
 BIN="target/release/hyperdu-cli"
 RUNS=5
 COLD=0
+ALLOW_STALE=0
 TREES=()
 
 while [[ $# -gt 0 ]]; do
@@ -37,6 +52,7 @@ while [[ $# -gt 0 ]]; do
     --bin) BIN="$2"; shift 2;;
     --runs) RUNS="$2"; shift 2;;
     --cold) COLD=1; shift;;
+    --allow-stale) ALLOW_STALE=1; shift;;
     -h|--help) usage; exit 0;;
     *) TREES+=("$1"); shift;;
   esac
@@ -52,14 +68,71 @@ if [[ ! -x "$BIN" ]]; then
   exit 2
 fi
 
+repo_root() { git rev-parse --show-toplevel 2>/dev/null || echo "."; }
+
+# Abort when the binary predates the sources. A warning would be read past.
+check_not_stale() {
+  [[ $ALLOW_STALE -eq 1 ]] && return 0
+  local root newest bin_mtime src_mtime
+  root=$(repo_root)
+  newest=$(find "$root/hyperdu-core/src" "$root/hyperdu-cli/src" \
+                "$root/hyperdu-core/Cargo.toml" "$root/hyperdu-cli/Cargo.toml" \
+                "$root/Cargo.toml" -type f -newer "$BIN" -print -quit 2>/dev/null)
+  [[ -z "$newest" ]] && return 0
+  bin_mtime=$(date -r "$BIN" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo '?')
+  src_mtime=$(date -r "$newest" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo '?')
+  cat >&2 <<EOF
+error: '$BIN' is older than the sources; the numbers would describe a build that
+       no longer exists.
+         binary : $bin_mtime
+         source : $src_mtime  ($newest)
+       Rebuild (cargo build --release), or pass --allow-stale if that is the
+       point of the run.
+EOF
+  exit 3
+}
+
+# hyperdu excludes nothing by default now, but say so explicitly: a benchmark
+# must not depend on whatever the default happens to be at the time.
 hyperdu() { "$BIN" "$1" --top 1 --exclude "" --one-file-system "${@:2}"; }
 
+hyperdu_files() {
+  hyperdu "$1" 2>/dev/null | sed -n 's/.*files=\([0-9]*\).*/\1/p' | tail -1
+}
+
+# du and hyperdu must walk the same set, or the comparison measures the filter.
+check_same_workload() {
+  local tree=$1 find_files=$2 hd_files
+  hd_files=$(hyperdu_files "$tree")
+  [[ "$hd_files" == "$find_files" ]] && return 0
+  cat >&2 <<EOF
+error: hyperdu and find disagree on '$tree'; the two tools are not scanning the
+       same set, so any timing from this tree is meaningless.
+         find    : $find_files files
+         hyperdu : ${hd_files:-<none>} files
+       Check the active exclude patterns (hyperdu prints them under "Excludes:").
+EOF
+  exit 4
+}
+
+median_ms() {
+  # Reads whitespace-separated integers on stdin.
+  tr ' ' '\n' | grep -v '^$' | sort -n | awk '
+    { a[NR] = $1 }
+    END { print (NR % 2) ? a[(NR + 1) / 2] : int((a[NR / 2] + a[NR / 2 + 1]) / 2) }'
+}
+
+time_once_ms() {
+  local s
+  s=$(date +%s%N)
+  "$@" >/dev/null 2>&1
+  echo $(( ($(date +%s%N) - s) / 1000000 ))
+}
+
 best_ms() {
-  local lo=99999999 t s
+  local lo=99999999 t
   for _ in $(seq 1 "$RUNS"); do
-    s=$(date +%s%N)
-    "$@" >/dev/null 2>&1
-    t=$(( ($(date +%s%N) - s) / 1000000 ))
+    t=$(time_once_ms "$@")
     (( t < lo )) && lo=$t
   done
   echo "$lo"
@@ -75,44 +148,69 @@ drop_caches() {
   sleep 1
 }
 
-cold_ms() {
-  local lo=99999999 t s
-  for _ in $(seq 1 3); do
+# Burn off the device's burst allowance, then alternate the tools so both see
+# the same steady state, and report medians.
+cold_pair_ms() {
+  local tree=$1 i du_samples="" hd_samples=""
+  for _ in 1 2 3; do
     drop_caches
-    s=$(date +%s%N)
-    "$@" >/dev/null 2>&1
-    t=$(( ($(date +%s%N) - s) / 1000000 ))
-    (( t < lo )) && lo=$t
+    du -sx "$tree" >/dev/null 2>&1
   done
-  echo "$lo"
+  for ((i = 0; i < 5; i++)); do
+    drop_caches
+    du_samples+=" $(time_once_ms du -sx "$tree")"
+    drop_caches
+    hd_samples+=" $(time_once_ms hyperdu "$tree")"
+  done
+  echo "$(echo "$du_samples" | median_ms) $(echo "$hd_samples" | median_ms)"
 }
 
-echo "host:    $(uname -sr)  vCPU=$(nproc 2>/dev/null || echo '?')"
-echo "du:      $(du --version 2>/dev/null | head -1 || echo 'unknown')"
-echo "hyperdu: $BIN"
-echo "runs:    $RUNS (minimum reported)"
+physical_cores() {
+  awk -F: '/^core id/ { ids[$2] = 1 } END { n = 0; for (k in ids) n++; print (n ? n : "?") }' \
+    /proc/cpuinfo 2>/dev/null || echo '?'
+}
+
+# Everything needed to reproduce a run, or to notice that an old one is not
+# comparable to a new one.
+root=$(repo_root)
+echo "host:     $(uname -sr)  vCPU=$(nproc 2>/dev/null || echo '?')  physical=$(physical_cores)"
+echo "commit:   $(git -C "$root" rev-parse --short HEAD 2>/dev/null || echo '?')"
+dirty=$(git -C "$root" status --porcelain 2>/dev/null | wc -l)
+if [[ "$dirty" -gt 0 ]]; then
+  echo "tree:     DIRTY ($dirty uncommitted change(s)) -- not reproducible from the commit alone"
+else
+  echo "tree:     clean"
+fi
+echo "du:       $(du --version 2>/dev/null | head -1 || echo 'unknown')"
+echo "hyperdu:  $BIN  ($(date -r "$BIN" '+%Y-%m-%d %H:%M:%S' 2>/dev/null || echo '?'))"
+echo "warm:     minimum of $RUNS runs"
+[[ $COLD -eq 1 ]] && echo "cold:     3 burn-in runs, then 5 interleaved pairs, median reported"
 echo
 
-printf '%-24s %-9s %-8s %8s %8s %7s' 'tree' 'files' 'dirs' 'du' 'hyperdu' 'ratio'
+check_not_stale
+
+printf '%-24s %-9s %-8s %-8s %8s %8s %7s' 'tree' 'files' 'dirs' 'fs' 'du' 'hyperdu' 'ratio'
 [[ $COLD -eq 1 ]] && printf ' %9s %9s %7s' 'du-cold' 'hd-cold' 'ratio'
 printf '\n'
 
 for tree in "${TREES[@]}"; do
   files=$(find "$tree" -xdev -type f 2>/dev/null | wc -l)
   dirs=$(find "$tree" -xdev -type d 2>/dev/null | wc -l)
+  fstype=$(stat -f -c %T "$tree" 2>/dev/null || echo '?')
+
+  check_same_workload "$tree" "$files"
 
   du -sx "$tree" >/dev/null 2>&1      # warm both tools identically
   hyperdu "$tree" >/dev/null 2>&1
   du_ms=$(best_ms du -sx "$tree")
   hd_ms=$(best_ms hyperdu "$tree")
 
-  printf '%-24s %-9s %-8s %7sms %7sms %6.2fx' \
-    "$(basename "$tree")" "$files" "$dirs" "$du_ms" "$hd_ms" \
+  printf '%-24s %-9s %-8s %-8s %7sms %7sms %6.2fx' \
+    "$(basename "$tree")" "$files" "$dirs" "$fstype" "$du_ms" "$hd_ms" \
     "$(awk -v a="$du_ms" -v b="$hd_ms" 'BEGIN { print (b>0 ? a/b : 0) }')"
 
   if [[ $COLD -eq 1 ]]; then
-    cdu_ms=$(cold_ms du -sx "$tree")
-    chd_ms=$(cold_ms hyperdu "$tree")
+    read -r cdu_ms chd_ms <<<"$(cold_pair_ms "$tree")"
     printf ' %8sms %8sms %6.2fx' "$cdu_ms" "$chd_ms" \
       "$(awk -v a="$cdu_ms" -v b="$chd_ms" 'BEGIN { print (b>0 ? a/b : 0) }')"
   fi


### PR DESCRIPTION
Closes #17
Closes #18

## 計測規約をスクリプトに組み込む（#17）

`scripts/bench_du.sh` が公平性の条件を**文書ではなく実行時に強制**するようにしました。3 つとも、実際にやらかした失敗が根拠です。

| 検出 | 背景 | 動作 |
|---|---|---|
| **古いバイナリ** | `cargo build --features X` が `target/release` を上書きし、後の計測が古いバイナリを測っていた | ソースの最新 mtime と比較し**終了コード 3 で中断**（`--allow-stale` で意図的に回避可能） |
| **走査対象の不一致** | 既定除外の `.git` が `.github` に部分一致し、HyperDU だけ 437 ディレクトリ少なく走査していた | `find` のファイル数と突き合わせ、**終了コード 4 で中断** |
| **cold の最小値** | EBS gp3 のバースト枯渇で同一条件が `0.495, 0.495, 0.813, 0.886, 0.877, 0.884, 0.867, 0.889` と**二峰性**。最小値はバースト状態だけを拾う | burn-in 3 回 → 両ツールを**交互**に 5 組 → **中央値** |

warm は最小値のままです。25 回反復で ±1.5% に収まることを実測しており、最小値が代表値として妥当だからです。**cold と warm で手法を変える理由**をスクリプト冒頭のコメントに残しました。

ヘッダに commit、未コミット変更の有無、物理コア数、ファイルシステム種別、カーネル、バイナリの mtime を出力します。

### 動作確認

**1. stale binary 検出**（WSL2）

```
error: '/tmp/hdu-target/release/hyperdu-cli' is older than the sources; ...
         binary : 2026-09-05 01:19:57
         source : 2026-09-05 01:37:42  (.../hyperdu-core/src/fs_strategy.rs)
```

**2. 不一致検出**（`--exclude .git` を注入）

```
error: hyperdu and find disagree on '/root/.cargo/registry/src'; ...
         find    : 34998 files
         hyperdu : 34248 files
```

**3. 正常系**（WSL2 / ext4）

```
tree                     files     dirs     fs             du  hyperdu   ratio
src                      34998     6001     ext2/ext3     474ms      66ms   7.18x
```

**4. cold プロトコル**（EC2 t3.large / xfs）

```
host:     Linux 6.1.182-227.379.amzn2023.x86_64  vCPU=2  physical=1
cold:     3 burn-in runs, then 5 interleaved pairs, median reported

tree                     files     dirs     fs             du  hyperdu   ratio   du-cold   hd-cold   ratio
rust                     62621     4734     xfs          151ms     111ms   1.36x     2593ms      466ms   5.56x
git                      4874      242      xfs           13ms      13ms   1.00x      186ms       92ms   2.02x
```

`physical=1`（物理 1 コア + SMT）が正しく検出され、以前の手動計測（5.40x / 2.01x）とも一致します。

## README の性能表を実測値に置き換える（#18）

「理論値」と明記された架空の表を削除し、上記の実測値に差し替えました。

- **warm の比は物理コア数の関数**であることを明記（du は単一スレッド。t3.large は物理 1 コアなので 1.00〜1.36x、WSL2 の物理 8 コアでは 7.18x）
- **cold こそ実用上の主戦場**であることを明記（容量調査は通常 1 回きり）
- **なぜ Linux は Windows より差が小さいか**を構造的に説明（`struct dirent64` にサイズを入れる場所がなく、VFS の `dir_emit()` / `filldir64()` の署名も `(name, namelen, ino, dtype)` しか受け取らない）
- `bench_du.sh` の使い方と 3 つの検出内容を追記

### プラットフォーム記述の訂正

「Linux は未確認」という記述が 4 箇所ありましたが、**事実に反します**。本日 EC2（Amazon Linux 2023 / xfs）と WSL2（ext4）で実機検証しており、CI にも Linux ジョブがあります。「検証済み」に改めました。macOS は実機検証していないため「実機未検証」のまま残しています。
