### PR TITLE
feat: --approximate にサンプリング率を導入する（#14 / 基準未達）

### DIFF
--- a/hyperdu-cli/src/main.rs
+++ b/hyperdu-cli/src/main.rs
@@ -283,6 +283,21 @@ struct Args {
     )]
     approximate: bool,
 
+    /// With --approximate, stat 1 file in N instead of guessing every size
+    #[arg(
+        long = "sample-rate",
+        value_name = "N",
+        default_value_t = 0,
+        long_help = "--approximate 使用時に、N 件に 1 件だけ statx で実サイズを取得します。\n\
+    0（既定）は statx を一切呼ばず全ファイルを固定値とみなす従来の挙動です。\n\
+    1 は全件取得（正確ですが通常スキャンと同速）。\n\
+    2 以上では、各ディレクトリの先頭16件は必ず取得したうえで N 件おきに取得し、\n\
+    取得しなかったファイルには「そのディレクトリの」サンプル平均を割り当てます。\n\
+    ファイルサイズは裾が重いため、大きなファイルを1つ外すと総量が大きく外れます。\n\
+    誤差が許容できるかは必ず実測してください。"
+    )]
+    sample_rate: u32,
+
     /// Run tuning only (no scan); prints recommended dir_yield_every and exits
     #[arg(
         long = "tune-only",
@@ -914,6 +929,15 @@ fn main() -> Result<()> {
     }
     if args.approximate {
         opt.approximate_sizes = true;
+    }
+    opt.size_sample_rate = args.sample_rate;
+    // Silently ignoring this would let someone believe they had traded accuracy
+    // for speed when they had done neither.
+    if args.sample_rate > 0 && !opt.approximate_sizes {
+        eprintln!(
+            "warning: --sample-rate {} has no effect without --approximate (or a --perf preset that implies it)",
+            args.sample_rate
+        );
     }
     opt.one_file_system = args.one_file_system;
     if args.follow_links && !matches!(opt.compat_mode, hyperdu_core::CompatMode::HyperDU) {

--- a/hyperdu-core/src/lib.rs
+++ b/hyperdu-core/src/lib.rs
@@ -143,7 +143,7 @@ pub struct Options {
     /// Only consulted when `approximate_sizes` is set.
     pub size_sample_rate: u32,
     pub active_threads: Arc<AtomicUsize>, // runtime-tunable active worker threads (<= threads)
-    pub cancel: Arc<AtomicBool>, // cooperative cancellation
+    pub cancel: Arc<AtomicBool>,          // cooperative cancellation
     pub exclude_ac: Option<AhoCorasick>,
     pub exclude_regex: Vec<String>,
     pub exclude_glob: Vec<String>,

--- a/hyperdu-core/src/lib.rs
+++ b/hyperdu-core/src/lib.rs
@@ -130,7 +130,18 @@ pub struct Options {
     pub progress_sample_callback: Option<ProgressSampleCallback>,
     pub compute_physical: bool, // if false, use logical size as physical (faster)
     pub dir_yield_every: Arc<AtomicUsize>, // 0 = no yielding; split large dirs every N entries
-    pub approximate_sizes: bool, // if true and compute_physical=false, estimate regular file size (e.g., 4KiB) to avoid statx
+    pub approximate_sizes: bool, // if true and compute_physical=false, estimate regular file size to avoid statx
+    /// How many files to stat in approximate mode, as 1 in N.
+    ///
+    /// 0 stats nothing and charges every file a fixed guess -- the original
+    /// behaviour, and wrong by however much the guess is wrong. 1 stats
+    /// everything, which is exact and no faster than a normal scan. Values in
+    /// between stat a sample and charge the unsampled files that directory's
+    /// sampled mean, which keeps the error local: a directory of large files
+    /// is not estimated from a directory of small ones.
+    ///
+    /// Only consulted when `approximate_sizes` is set.
+    pub size_sample_rate: u32,
     pub active_threads: Arc<AtomicUsize>, // runtime-tunable active worker threads (<= threads)
     pub cancel: Arc<AtomicBool>, // cooperative cancellation
     pub exclude_ac: Option<AhoCorasick>,
@@ -231,6 +242,7 @@ impl Default for Options {
                     .unwrap_or(0),
             )),
             approximate_sizes: false,
+            size_sample_rate: 0,
             active_threads: Arc::new(AtomicUsize::new(threads_default.max(1))),
             exclude_ac: None,
             exclude_regex: Vec::new(),

--- a/hyperdu-core/src/platform/linux_helpers.rs
+++ b/hyperdu-core/src/platform/linux_helpers.rs
@@ -402,6 +402,91 @@ pub fn packed_dev(dev: libc::dev_t) -> u64 {
     ((libc::major(dev) as u64) << 32) | (libc::minor(dev) as u64)
 }
 
+/// Decides which files in a directory get a real `statx` in approximate mode,
+/// and what to charge the ones that do not.
+///
+/// `--approximate` used to charge every regular file a flat 4KiB, which is
+/// wrong by however much the guess is wrong -- and file sizes are heavy-tailed,
+/// so a single missed large file moves the total more than every small file
+/// combined. Sampling turns that into a dial.
+///
+/// Two rules keep the error bounded:
+///
+///   - The first `SAMPLER_PRIMER` regular files of every directory are always
+///     stat'ed. A directory with no more than that many files is therefore
+///     exact, which covers most directories in a source tree.
+///   - Unsampled files are charged the mean of *this directory's* samples, not
+///     a global mean. A directory of VM images must not be estimated from a
+///     directory of source files.
+///
+/// State is per directory and lives on the stack: four counters, no allocation.
+pub(crate) struct SizeSampler {
+    /// 1 in N. 0 disables statx entirely (the original flat-guess behaviour).
+    rate: u32,
+    /// Regular files seen so far in this directory.
+    seen: u64,
+    /// Files actually stat'ed, and the total of their sizes.
+    sampled_files: u64,
+    sampled_bytes: u64,
+}
+
+/// Regular files at the head of a directory that are always stat'ed, so a small
+/// directory is exact and a large one starts from a real mean, not a guess.
+const SAMPLER_PRIMER: u64 = 16;
+
+/// Charged to a regular file when nothing in its directory has been stat'ed
+/// yet. This is what plain `--approximate` charges every file, and it is only
+/// a placeholder: one sample replaces it.
+///
+/// `src/constants.rs` declares the same value but is not reachable -- no `mod
+/// constants;` exists in lib.rs, so the file is not compiled. Defining it here
+/// keeps this module self-contained rather than reviving dead code.
+pub(crate) const APPROXIMATE_FILE_SIZE: u64 = 4096;
+
+impl SizeSampler {
+    pub(crate) fn new(opt: &crate::Options) -> Self {
+        Self {
+            rate: opt.size_sample_rate,
+            seen: 0,
+            sampled_files: 0,
+            sampled_bytes: 0,
+        }
+    }
+
+    /// True when sampling is active at all. False means the caller keeps the
+    /// old flat-guess behaviour, so `--approximate` without a rate is unchanged.
+    pub(crate) fn is_sampling(&self) -> bool {
+        self.rate > 0
+    }
+
+    /// Call once per regular file, before deciding whether to stat it.
+    /// Returns true when this file must be stat'ed.
+    pub(crate) fn wants_stat(&mut self) -> bool {
+        self.seen += 1;
+        if self.rate <= 1 {
+            // rate 1 stats everything; rate 0 never reaches here.
+            return self.rate == 1;
+        }
+        self.seen <= SAMPLER_PRIMER || self.seen % (self.rate as u64) == 0
+    }
+
+    /// Feed back the real size of a file that was stat'ed.
+    pub(crate) fn observe(&mut self, logical: u64) {
+        self.sampled_files += 1;
+        self.sampled_bytes = self.sampled_bytes.saturating_add(logical);
+    }
+
+    /// Size to charge a file that was not stat'ed: this directory's sampled
+    /// mean, or the flat estimate before any sample exists.
+    pub(crate) fn estimate(&self) -> u64 {
+        if self.sampled_files == 0 {
+            APPROXIMATE_FILE_SIZE
+        } else {
+            self.sampled_bytes / self.sampled_files
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -417,5 +502,88 @@ mod tests {
             packed_dev(libc::makedev(8, 1)),
             packed_dev(libc::makedev(9, 1))
         );
+    }
+
+    fn sampler(rate: u32) -> SizeSampler {
+        let mut opt = crate::Options::default();
+        opt.size_sample_rate = rate;
+        SizeSampler::new(&opt)
+    }
+
+    #[test]
+    fn rate_zero_does_not_sample_at_all() {
+        let s = sampler(0);
+        assert!(!s.is_sampling());
+        assert_eq!(s.estimate(), APPROXIMATE_FILE_SIZE);
+    }
+
+    #[test]
+    fn rate_one_stats_every_file() {
+        let mut s = sampler(1);
+        assert!(s.is_sampling());
+        for _ in 0..100 {
+            assert!(s.wants_stat());
+        }
+    }
+
+    #[test]
+    fn a_directory_no_larger_than_the_primer_is_exact() {
+        let mut s = sampler(64);
+        for _ in 0..SAMPLER_PRIMER {
+            assert!(s.wants_stat(), "every file up to the primer must be stat'ed");
+        }
+    }
+
+    #[test]
+    fn past_the_primer_only_every_nth_file_is_stated() {
+        let rate = 8u32;
+        let mut s = sampler(rate);
+        for _ in 0..SAMPLER_PRIMER {
+            s.wants_stat();
+        }
+        // Files SAMPLER_PRIMER+1 .. +rate: exactly one lands on the multiple.
+        let stated = (0..rate).filter(|_| s.wants_stat()).count();
+        assert_eq!(stated, 1, "expected 1 in {rate} past the primer");
+    }
+
+    #[test]
+    fn unsampled_files_are_charged_this_directorys_mean() {
+        let mut s = sampler(4);
+        s.observe(1000);
+        s.observe(3000);
+        assert_eq!(s.estimate(), 2000, "mean of the samples, not a global guess");
+    }
+
+    #[test]
+    fn estimate_falls_back_to_the_flat_guess_before_any_sample() {
+        let s = sampler(4);
+        assert_eq!(s.estimate(), APPROXIMATE_FILE_SIZE);
+    }
+
+    // File sizes are heavy-tailed: this is the case the flat 4KiB guess got
+    // catastrophically wrong, and the reason the mean is taken per directory.
+    #[test]
+    fn a_large_file_among_small_ones_moves_the_estimate() {
+        let mut s = sampler(4);
+        for _ in 0..9 {
+            s.observe(1024);
+        }
+        let without_large = s.estimate();
+        s.observe(10 * 1024 * 1024 * 1024);
+        assert!(
+            s.estimate() > without_large * 100,
+            "one large sample must dominate: {} -> {}",
+            without_large,
+            s.estimate()
+        );
+    }
+
+    #[test]
+    fn observe_saturates_instead_of_overflowing() {
+        let mut s = sampler(2);
+        s.observe(u64::MAX);
+        s.observe(u64::MAX);
+        // Must not panic in debug; the mean stays finite and usable.
+        assert!(s.estimate() > 0);
     }
 }

--- a/hyperdu-core/src/platform/linux_helpers.rs
+++ b/hyperdu-core/src/platform/linux_helpers.rs
@@ -479,11 +479,9 @@ impl SizeSampler {
     /// Size to charge a file that was not stat'ed: this directory's sampled
     /// mean, or the flat estimate before any sample exists.
     pub(crate) fn estimate(&self) -> u64 {
-        if self.sampled_files == 0 {
-            APPROXIMATE_FILE_SIZE
-        } else {
-            self.sampled_bytes / self.sampled_files
-        }
+        self.sampled_bytes
+            .checked_div(self.sampled_files)
+            .unwrap_or(APPROXIMATE_FILE_SIZE)
     }
 }
 

--- a/hyperdu-core/src/platform/linux_helpers.rs
+++ b/hyperdu-core/src/platform/linux_helpers.rs
@@ -530,7 +530,10 @@ mod tests {
     fn a_directory_no_larger_than_the_primer_is_exact() {
         let mut s = sampler(64);
         for _ in 0..SAMPLER_PRIMER {
-            assert!(s.wants_stat(), "every file up to the primer must be stat'ed");
+            assert!(
+                s.wants_stat(),
+                "every file up to the primer must be stat'ed"
+            );
         }
     }
 
@@ -551,7 +554,11 @@ mod tests {
         let mut s = sampler(4);
         s.observe(1000);
         s.observe(3000);
-        assert_eq!(s.estimate(), 2000, "mean of the samples, not a global guess");
+        assert_eq!(
+            s.estimate(),
+            2000,
+            "mean of the samples, not a global guess"
+        );
     }
 
     #[test]

--- a/hyperdu-core/src/platform/linux_x86_64_impl.rs
+++ b/hyperdu-core/src/platform/linux_x86_64_impl.rs
@@ -78,6 +78,9 @@ pub fn process_dir(ctx: &ScanContext, dctx: &DirContext, map: &mut StatMap) {
     let mut counted = crate::platform::linux_helpers::FileCounter::new(opt);
     let mut yield_every = opt.dir_yield_every.load(Ordering::Relaxed);
     let mut processed: usize = 0;
+    // Per directory on purpose: a directory of VM images must not be estimated
+    // from the mean of a directory of source files.
+    let mut sampler = crate::platform::linux_helpers::SizeSampler::new(opt);
     loop {
         #[cfg(any(feature = "prof-tracy", feature = "prof-puffin"))]
         profiling::scope!("getdents64_loop");
@@ -146,9 +149,15 @@ pub fn process_dir(ctx: &ScanContext, dctx: &DirContext, map: &mut StatMap) {
                     ctx.enqueue_dir(child_path, depth + 1);
                 }
             } else if dtype == libc::DT_REG {
-                // Approximate size path to avoid statx when allowed
-                if !opt.compute_physical && opt.approximate_sizes && opt.min_file_size == 0 {
-                    let logical = 4096u64; // estimate 4KiB per regular file
+                // Approximate size path to avoid statx when allowed. With a
+                // sample rate set, a share of the files still get a real statx
+                // and the rest are charged this directory's sampled mean; see
+                // SizeSampler for why the mean is per directory.
+                let approx_ok =
+                    !opt.compute_physical && opt.approximate_sizes && opt.min_file_size == 0;
+                let sample_this = approx_ok && sampler.is_sampling() && sampler.wants_stat();
+                if approx_ok && !sample_this {
+                    let logical = sampler.estimate();
                     update_file_stats(stat_cur, logical, logical);
                     counted.record(name_slice, logical, logical);
                 } else {
@@ -197,6 +206,12 @@ pub fn process_dir(ctx: &ScanContext, dctx: &DirContext, map: &mut StatMap) {
                                 }
                             }
                             let logical = stx.stx_size;
+                            // After the dedupe check: a file skipped as a
+                            // duplicate contributes no bytes, so it must not
+                            // pull the directory's mean down either.
+                            if sample_this {
+                                sampler.observe(logical);
+                            }
                             if logical >= opt.min_file_size {
                                 let physical =
                                     calculate_physical_size(opt, logical, stx.stx_blocks);


### PR DESCRIPTION
Issue #14 の実装。ただし **Issue #14 が定めた基準を満たしていません。** 判断材料として計測結果をすべて記載します。

## 実装したもの

`Options::size_sample_rate`（CLI: `--sample-rate N`）を追加し、`--approximate` 時に N 件に 1 件だけ `statx` を呼ぶようにしました。

- 取得しなかったファイルには**そのディレクトリの**サンプル平均を割り当てる（VM イメージのディレクトリをソースコードのディレクトリの平均で推定させないため）
- 各ディレクトリの**先頭 16 件は必ず取得**するので、小さいディレクトリは正確になる
- 既定は `0` で従来の挙動を変えない

## 実装は正しい（合成ツリーで確認）

| ツリー | rate 1 | rate 4 | rate 16 | rate 64 |
|---|---|---|---|---|
| **uniform**（10KiB × 2000） | +0.00% | **+0.00%** | **+0.00%** | **+0.00%** |
| **heavytail**（1KiB × 1999 + 500MiB × 1） | +0.00% | **-99.61%** | **-99.61%** | **-99.61%** |

一様分布では誤差ゼロなのでロジックにバグはありません。**500MiB のファイル 1 個を取りこぼすと総量が壊滅します。**

## 基準 1: 精度 — **不合格**

Issue #14 の基準は「誤差 p95 が 10% を超えるならマージしない」。実ツリー 5 種での `du -sxb` との誤差です。

| tree | rate0（現行） | rate1 | rate4 | rate16 | rate64 |
|---|---|---|---|---|---|
| `/usr` | -89.0% | -0.0% | +44.2% | +3.6% | -21.0% |
| `/usr/lib` | -94.7% | -0.0% | +79.7% | +15.7% | -26.9% |
| `/usr/share` | -60.6% | -0.1% | -3.0% | -4.9% | +0.2% |
| `/etc` | +149.3% | -1.7% | -17.0% | -16.9% | -23.0% |
| `/var/lib` | -95.0% | -0.0% | -17.8% | -35.0% | -27.9% |

絶対誤差の分布（n=5 なので p95 は最大値）:

| rate | p50 | 最大 | 判定 |
|---|---|---|---|
| 4 | 17.8% | **79.7%** | 不合格 |
| 16 | 15.7% | **35.0%** | 不合格 |
| 64 | 23.0% | **27.9%** | 不合格 |

基準の 10% に対し、最良の rate 64 でも 2.8 倍外れます。

## 基準 2: statx 回数が 1/N — **不合格**

`strace -c`、`/usr/share`（21,815 ファイル）:

| rate | statx 回数 | 期待値 | 実際 |
|---|---|---|---|
| 1 | 21,826 | 21,815 | — |
| 4 | 11,545 | 約 5,456 | **53%（1/4 にならず）** |
| 16 | 8,990 | 約 1,364 | **41%** |
| 64 | 8,384 | 約 341 | **38%** |

**原因はプライマー（各ディレクトリ先頭 16 件を必ず statx）です。** 実際のツリーは小さなディレクトリの集まりなので、大半のファイルがプライマーに収まり、削減が 38% で頭打ちになります。

これは**設計上の二律背反**です。プライマーを外せば小さいディレクトリの精度が落ち、残せば速度が出ません。

## 基準 3: 速度 — 有意差なし

warm、5 回の最小値（ms）:

| tree | exact | rate0 | rate1 | rate4 | rate16 | rate64 |
|---|---|---|---|---|---|---|
| `/usr` | 49 | 38 | 79 | 53 | 44 | 35 |
| `/usr/lib` | 23 | 26 | 33 | 26 | 32 | 26 |
| `/usr/share` | 30 | 24 | 36 | 28 | 27 | 23 |
| `/etc` | 14 | 15 | 17 | 18 | 16 | 18 |
| `/var/lib` | 20 | 15 | 19 | 15 | 14 | 13 |

Issue が期待した「warm 3〜4 倍」に対し、**exact と rate64 の差はノイズの範囲**です（`/usr/lib` と `/etc` では逆に遅い）。statx が 38% しか減らないので当然の帰結です。

## 結論と推奨

**Issue #14 の基準に従えば、この PR はマージすべきではありません。** 精度・statx 削減・速度のいずれも基準を満たしません。

ただし本作業で**現行の出荷済み挙動に問題があること**が分かりました。

> **`--approximate`（rate 0）は実測で -95% から +149% まで外れています。**

`/etc` では総量が **2.5 倍**に、`/var/lib` では **1/20** になります。これは今この瞬間に出荷されている挙動です。サンプリングは不合格ですが、**現行の固定値よりは一貫して大幅にマシ**です。

判断の選択肢は 3 つあると考えます。

1. **サンプリングを却下し、`--approximate` 自体に警告を出す** — 一様サンプリングはヘビーテール分布に原理的に適合しません（合成ツリーで実証済み）。サイズを知らずにサイズで層別化はできないため、この方向に伸びしろは乏しいです
2. **明示的なオプトインとして残す** — 誤差プロファイルを文書化したうえで「ツリーの概形を掴む用途のみ」と限定する
3. **プライマーを可変にする** — 速度と精度のどちらを取るかを利用者に委ねる。ただし上記の二律背反は解消しません

私は **1 を推奨**します。#20（反証済み手法の決定記録）に沿えば、これは「構造的にもっともらしいが実測で否定された」5 例目です。

## 作業中に見つかった項目

- **`hyperdu-core/src/constants.rs` はデッドファイル**でした。`lib.rs` に `mod constants;` がなく、ビルドに含まれていません。`APPROXIMATE_FILE_SIZE` も未使用で、実際の値は `linux_x86_64_impl.rs` にハードコードされた `4096u64` でした。本 PR では `linux_helpers.rs` に定義してモジュールを自己完結させ、デッドコードは復活させていません。**別途削除を検討すべきです**
- **`linux_helpers.rs:210` の `get_entry_stats` にも 4096 のハードコードが残っています。** `#[allow(dead_code)]` が付いており現在は未使用ですが、サンプラーは通していません。復活させる場合は要対応です
- Issue #14 は「5 種 × 20 回」を要求していますが、**サンプリングは位置ベースで決定的**（乱数を使わない）なため、同じツリーでの反復は同じ結果になります。精度については反復に意味がありません。速度のみ 5 回の最小値を取りました
- 計測中、WSL の再起動で `/tmp` のバイナリが消え、**誤差表が全て -100% になる事故**がありました。バイナリ不在を無言で通したのが原因です。`bench-env`（#25）の `verify.sh` はこの種の検査を持っています

## テスト

`SizeSampler` の単体テスト 8 件を追加（全通過）。

```
test platform::linux_helpers::tests::a_directory_no_larger_than_the_primer_is_exact ... ok
test platform::linux_helpers::tests::a_large_file_among_small_ones_moves_the_estimate ... ok
test platform::linux_helpers::tests::estimate_falls_back_to_the_flat_guess_before_any_sample ... ok
test platform::linux_helpers::tests::observe_saturates_instead_of_overflowing ... ok
test platform::linux_helpers::tests::past_the_primer_only_every_nth_file_is_stated ... ok
test platform::linux_helpers::tests::rate_one_stats_every_file ... ok
test platform::linux_helpers::tests::rate_zero_does_not_sample_at_all ... ok
test platform::linux_helpers::tests::unsampled_files_are_charged_this_directorys_mean ... ok

test result: ok. 27 passed; 0 failed
```

## 計測環境

**Issue #14 が定める「計測環境の正」は EC2 t3.large / xfs ですが、本計測は WSL2（kernel 6.18、ext4、16 vCPU）で行いました。** AWS 認証情報が期限切れで EC2 を使えなかったためです。

精度の結論は環境に依存しません（同じファイル群に対する決定的な計算のため）。**速度の数値は環境依存なので、EC2 での再計測が要ります**。ただし statx が 38% しか減らない以上、速度が基準を満たす見込みは薄いと考えます。
