### PR TITLE
fix: 概算モードの誤差を警告する（#29）

### DIFF
--- a/hyperdu-cli/src/main.rs
+++ b/hyperdu-cli/src/main.rs
@@ -915,6 +915,19 @@ fn main() -> Result<()> {
     if args.approximate {
         opt.approximate_sizes = true;
     }
+    // Placed after every path that can set the flag, so `--perf turbo` -- which
+    // enables it without the user typing --approximate -- is caught too.
+    //
+    // Measured against `du -sxb`: +149% on /etc, -95% on /var/lib. The sign is
+    // not even consistent, so a caller cannot correct for it. Saying so costs
+    // one line on stderr and stops the totals being read as facts. See #29.
+    if opt.approximate_sizes {
+        eprintln!(
+            "warning: 概算モードが有効です。全ファイルを 4KiB とみなすため、\n\
+             \x20        合計は実測で -95%〜+149% 外れます（誤差の向きも一定しません）。\n\
+             \x20        正確な値が要る場合はこのモードを外してください。"
+        );
+    }
     opt.one_file_system = args.one_file_system;
     if args.follow_links && !matches!(opt.compat_mode, hyperdu_core::CompatMode::HyperDU) {
         opt.visited_bloom = Some(std::sync::Arc::new(hyperdu_core::Bloom::with_bits(1 << 20)));


### PR DESCRIPTION
Closes #29 の第一段階。**黙って外れた数値を出すのをやめます。**

## 問題

`--approximate` は全ての通常ファイルを一律 4096 バイトとみなします（`hyperdu-core/src/platform/linux_x86_64_impl.rs:151`）。ファイルサイズは裾が重いため、`du -sxb` を正とした実測で次のように外れます。

| tree | 誤差 | 意味 |
|---|---|---|
| `/etc` | **+149.3%** | 総量が **2.5 倍**に見える |
| `/var/lib` | **-95.0%** | 総量が **1/20** に見える |
| `/usr/lib` | -94.7% | |
| `/usr` | -89.0% | |
| `/usr/share` | -60.6% | |

**誤差の符号すら一定しないので、利用者が向きを見積もって補正することもできません。**

このツールの用途は「容量がどこへ消えたか」を知ることです。総量が 1/20 に見えるなら、その答えは得られません。

## この PR がすること

`approximate_sizes` が有効なとき、stderr に 3 行の警告を出します。

```
warning: 概算モードが有効です。全ファイルを 4KiB とみなすため、
         合計は実測で -95%〜+149% 外れます（誤差の向きも一定しません）。
         正確な値が要る場合はこのモードを外してください。
```

## 実装上の判断: 入力ではなく実効値で判定する

警告は `approximate_sizes` が**確定した後**に置きました。

`--perf turbo` はこのフラグを暗黙に立てるため（`hyperdu-cli/src/main.rs:823`）、**利用者が `--approximate` と入力していなくてもこの経路に入ります**。`args.approximate` を見て判定すると、この暗黙経路を取りこぼします。

動作確認:

| 呼び出し | 警告 |
|---|---|
| `--logical-only --approximate` | 出る |
| `--perf turbo`（暗黙） | **出る** |
| オプションなし | 出ない |

## 影響範囲

**標準出力と終了コードは変えていません。** ゴールデンテスト（`du_golden.rs`）は標準出力を比較するため影響しません。

- `cargo test -p hyperdu-core -p hyperdu-cli`: **41 件通過**
- `cargo clippy --all-targets`: 警告 0 件

## この PR に含めなかったもの

#29 に挙げた選択肢のうち、**挙動を変える判断が要るもの**は含めていません。

- `--perf turbo` から `approximate_sizes` を外す（選択肢 3）
- `--approximate` そのものの削除（選択肢 2）
- PR #26 のサンプリングをオプトインとして入れる（選択肢 4）

警告（選択肢 1）は挙動を変えず、誤解を防ぐ効果が最も大きいため先に入れました。**選択肢 3 は単独でも効果があり、この警告と組み合わせられます。**

## 経緯

Issue #14（サンプリング近似モード）の調査中に発見しました。#14 は「誤差 p95 < 10%」という自身の基準に対し 27.9〜79.7% で不合格となり打ち切りましたが、**その過程で現行の出荷済み挙動がさらに大きく外れていることが分かりました**。サンプリングは基準未達ですが、固定値よりは一貫してマシです（PR #26 に実装を残置）。

---

**計測環境**: WSL2（kernel 6.18、ext4、16 vCPU）。誤差は決定的な計算なので環境に依存しません。
