### PR TITLE
fix: --perf turbo が概算サイズを暗黙に有効にしないようにする（#29 選択肢 3）

### DIFF
--- a/hyperdu-cli/src/main.rs
+++ b/hyperdu-cli/src/main.rs
@@ -652,8 +652,9 @@ struct Args {
         value_enum,
         default_value_t = PerfArg::Balanced,
         long_help = "性能プロファイルを選択。\n\
-    turbo: 最速。論理サイズのみ（物理計算オフ）/概算サイズ/ハードリンク重複排除なし。\n\
-            Linuxでは io_uring の SQPOLL/COOP を想定し、初期バッチ/深さを強めに設定（ライブチューナで追従）。\n\
+    turbo: 最速。論理サイズのみ（物理計算オフ）/ハードリンク重複排除なし。\n\
+            サイズは正確です。概算にする場合は --approximate を明示してください\n\
+            （合計が実測で -95%〜+149% 外れます）。\n\
     balanced: 既定（バランス重視）。\n\
     strict: 互換性最優先（du互換を厳格化/ハードリンク重複排除/エラー出力など）。"
     )]
@@ -818,9 +819,15 @@ fn main() -> Result<()> {
     // Apply performance profile (maps to existing flags)
     match args.perf {
         PerfArg::Turbo => {
-            // fastest: approximate sizes, skip dedupe, lightweight errors
+            // Fastest, but still answering the question that was asked.
+            //
+            // This used to set `approximate_sizes`, which charges every file a
+            // flat 4KiB. Measured against `du -sxb` that is wrong by -95% on
+            // /var/lib and +149% on /etc -- and the sign is not consistent, so
+            // a caller cannot correct for it. "Fast" is a request for a quicker
+            // answer, not for a different one, so the guess is opt-in via
+            // --approximate rather than implied here. See #29.
             opt.compute_physical = false;
-            opt.approximate_sizes = true;
             opt.count_hardlinks = true; // do not dedupe
                                         // keep compat in HyperDU unless明示
                                         // io_uring のチューニングはオプトインのままにする。


### PR DESCRIPTION
Issue #29 の選択肢 3。**`--perf turbo` が概算サイズを暗黙に有効にするのをやめます。**

## 「速い」は違う答えを求める指定ではない

`--perf turbo` は `approximate_sizes` を立てていました。これは全ファイルを一律 4096 バイトとみなすもので、`du -sxb` を正とした実測で次のように外れます。

| tree | 誤差 | 意味 |
|---|---|---|
| `/etc` | **+149.3%** | 総量が **2.5 倍**に見える |
| `/var/lib` | **-95.0%** | 総量が **1/20** に見える |

**誤差の符号すら一定しないので、利用者が向きを見積もって補正することもできません。**

そして利用者は **`--approximate` と入力していません**。速い答えを求めただけで、違う答えを求めたわけではないのに、総量が 1/20 に見える結果を受け取っていました。

## 変更後

```
=== scripts 配下（74,350 バイト）===
turbo:    74350
exact:    74350
```

**以前は概算値になっていました。**

速度は落ちますが、これは正確さと引き換えの低下ではなく、**正確さを取り戻したぶんの低下**です。`turbo` には物理サイズ計算のスキップとハードリンク重複排除のスキップが残っており、速度の利点は保たれています。

概算を使いたい場合は **`--approximate` を明示**します。挙動はそのまま残してあります。

## 副次的な修正: 存在しない機能の案内を削除

`--perf` のヘルプに次の記述が残っていました。

> Linuxでは io_uring の SQPOLL/COOP を想定し、初期バッチ/深さを強めに設定

**io_uring バックエンドは #19 / PR #23 で削除済み**です。存在しない機能を案内していたので削除しました。

## 検証

- `cargo test -p hyperdu-core -p hyperdu-cli`: **41 件通過**
- `cargo clippy --all-targets`: 警告 0 件
- `--perf turbo` の総量が exact と一致することを実測

## PR #30 との関係

**独立して評価できます。**

| PR | 選択肢 | 内容 | 挙動の変更 |
|---|---|---|---|
| **#30** | 1 | `--approximate` 使用時に stderr へ警告 | **なし** |
| **本 PR** | 3 | `--perf turbo` から概算を外す | **あり** |

Issue #29 に書いたとおり「3 は単独でも効果があり、1 と組み合わせられます」。両方入れると、`--approximate` を明示した利用者だけが警告つきで概算を使う形になります。

## 含めなかった選択肢

- **選択肢 2（`--approximate` の削除）** — より踏み込んだ判断が要ります
- **選択肢 4（サンプリングの導入）** — PR #26 に実装がありますが、Issue #14 の基準（誤差 p95 < 10%）を満たさず打ち切り済みです

## 判断をお願いしたい点

**`--perf turbo` の速度が落ちます。** 「turbo は速さのためなら精度を捨ててよい」という設計意図があったのなら、この PR は取り下げます。

その場合でも、**turbo が -95%〜+149% 外れることは help に明記すべき**と考えます（現状は「概算サイズ」としか書かれておらず、桁が違う可能性が伝わりません）。

---

**計測環境**: 誤差の数値は WSL2（kernel 6.18、ext4）、turbo/exact の一致確認は Windows 11 / NTFS。誤差は決定的な計算なので環境に依存しません。
