### PR TITLE
feat: NTFS 解析・MFT 読み出し・--mft（#15 / 一致検証のみ残)

### DIFF
--- a/hyperdu-cli/src/main.rs
+++ b/hyperdu-cli/src/main.rs
@@ -283,6 +283,19 @@ struct Args {
     )]
     approximate: bool,
 
+    /// Read the NTFS $MFT directly (Windows, volume root, administrator)
+    #[arg(
+        long = "mft",
+        action = ArgAction::SetTrue,
+        long_help = "NTFS の $MFT を直接読んでボリューム全体を走査します（Windows のみ）。\n\
+    以下のいずれかに当てはまる場合は自動的に通常の列挙へ切り替わります。\n\
+      - 管理者権限で実行していない\n\
+      - 走査対象がボリュームのルート（例: C:\\）でない\n\
+      - NTFS でない、または $MFT の解析に失敗した\n\
+    切り替わっても結果は正しく、遅くなるだけです。"
+    )]
+    mft: bool,
+
     /// Run tuning only (no scan); prints recommended dir_yield_every and exits
     #[arg(
         long = "tune-only",
@@ -903,6 +916,7 @@ fn main() -> Result<()> {
              \x20        正確な値が要る場合はこのモードを外してください。"
         );
     }
+    opt.use_mft = args.mft;
     opt.one_file_system = args.one_file_system;
     if args.follow_links && !matches!(opt.compat_mode, hyperdu_core::CompatMode::HyperDU) {
         opt.visited_bloom = Some(std::sync::Arc::new(hyperdu_core::Bloom::with_bits(1 << 20)));
@@ -1236,12 +1250,44 @@ fn main() -> Result<()> {
         ));
     }
 
+    // Whether `--mft` could apply to this path at all. Elevation and the
+    // filesystem type are checked in the core, which is where the fallback
+    // lives; this only catches the case the user can see and fix themselves.
+    fn looks_like_volume_root(p: &std::path::Path) -> bool {
+        #[cfg(windows)]
+        {
+            use std::path::{Component, Prefix};
+            let mut c = p.components();
+            let is_disk = matches!(
+                c.next(),
+                Some(Component::Prefix(pre))
+                    if matches!(pre.kind(), Prefix::Disk(_) | Prefix::VerbatimDisk(_))
+            );
+            is_disk && matches!(c.next(), Some(Component::RootDir)) && c.next().is_none()
+        }
+        #[cfg(not(windows))]
+        {
+            let _ = p;
+            false
+        }
+    }
+
     // Roots: if none provided, use current directory
     let roots: Vec<PathBuf> = if args.roots.is_empty() {
         vec![PathBuf::from(".")]
     } else {
         args.roots.clone()
     };
+
+    // Falling back silently would let someone believe they had measured the
+    // volume the fast way when they had not. The scan is still correct, so this
+    // is a warning rather than an error.
+    if args.mft && !roots.iter().any(|r| looks_like_volume_root(r)) {
+        eprintln!(
+            "warning: --mft はボリュームのルート（例: C:\\）にのみ適用されます。\n\
+             \x20        指定された対象では通常の列挙で走査します。"
+        );
+    }
 
     // Quick Win: Minimal FS detection to improve defaults on DrvFS/Network FS
     #[cfg(target_os = "linux")]

--- a/hyperdu-core/src/lib.rs
+++ b/hyperdu-core/src/lib.rs
@@ -191,6 +191,15 @@ pub struct Options {
     pub win_allow_handle: bool,
     /// Legacy Windows knob (see `win_allow_handle`). No effect.
     pub win_handle_sample_every: u64,
+    /// Read the volume's `$MFT` directly instead of enumerating directories
+    /// (Windows/NTFS only).
+    ///
+    /// Opt-in, and never a default: it needs administrator rights, and it
+    /// reports the volume's own view rather than the one a user sees through
+    /// the filesystem. When it cannot be used -- not elevated, not NTFS, not a
+    /// whole volume, or the parse fails -- the scan falls back to enumeration
+    /// rather than returning a partial answer.
+    pub use_mft: bool,
 }
 
 impl std::fmt::Debug for Options {
@@ -258,6 +267,7 @@ impl Default for Options {
             prefer_inner_rayon: false,
             win_allow_handle: false,
             win_handle_sample_every: 64,
+            use_mft: false,
         }
     }
 }
@@ -537,6 +547,14 @@ pub fn scan_roots(roots: &[PathBuf], opt: &Options) -> Vec<(PathBuf, Result<Stat
 }
 
 pub fn scan_directory(root: impl AsRef<Path>, opt: &Options) -> Result<StatMap> {
+    let root = root.as_ref();
+    // Reading the MFT answers the whole volume at once, so it replaces the walk
+    // rather than feeding it. Anything that makes it inapplicable returns None
+    // and the normal scan runs: a slower correct answer beats a fast partial
+    // one. Off unless `use_mft` is set.
+    if let Some(map) = platform::scan_volume_via_mft(root, opt) {
+        return Ok(map);
+    }
     let scanner = Arc::new(crate::scanner::platform_scanner());
     scan_directory_with(root, opt, scanner)
 }

--- a/hyperdu-core/src/platform/mod.rs
+++ b/hyperdu-core/src/platform/mod.rs
@@ -49,6 +49,24 @@ pub fn process_dir_wrapped(ctx: &ScanContext, dir_ctx: &DirContext, map: &mut St
     windows_impl::process_dir(ctx, dir_ctx, map)
 }
 
+/// Scan a whole volume by reading its `$MFT`, or `None` when that is not
+/// possible here.
+///
+/// Unlike the enumeration backends this is not per-directory: the MFT is read
+/// once for the whole volume. `None` covers every reason it might not apply --
+/// not Windows, not elevated, not NTFS, not a volume root -- and the caller
+/// falls back to enumeration. Reporting a partial answer would be worse than
+/// being slower.
+#[cfg(windows)]
+pub fn scan_volume_via_mft(root: &std::path::Path, opt: &crate::Options) -> Option<StatMap> {
+    windows_impl::scan_volume_via_mft(root, opt)
+}
+
+#[cfg(not(windows))]
+pub fn scan_volume_via_mft(_root: &std::path::Path, _opt: &crate::Options) -> Option<StatMap> {
+    None
+}
+
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 pub fn process_dir_wrapped(ctx: &ScanContext, dir_ctx: &DirContext, map: &mut StatMap) {
     linux_x86_64_impl::process_dir(ctx, dir_ctx, map);

--- a/hyperdu-core/src/platform/windows_impl/mft.rs
+++ b/hyperdu-core/src/platform/windows_impl/mft.rs
@@ -388,6 +388,244 @@ pub(crate) fn parse_data_sizes(rec: &[u8], attr: &AttrHeader) -> Option<DataSize
     })
 }
 
+// --- run lists ---------------------------------------------------------------
+
+/// One extent of a non-resident attribute: where it starts on the volume and
+/// how many clusters it covers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Run {
+    /// Starting cluster on the volume. `None` for a sparse run, which occupies
+    /// no space -- counting it as allocated would inflate every sparse file.
+    pub(crate) lcn: Option<u64>,
+    pub(crate) length: u64,
+}
+
+/// Decode the run list of a non-resident attribute.
+///
+/// `$MFT` is itself a file, and it is not necessarily contiguous. Without this
+/// the MFT can only be read as far as its first extent, which on a fragmented
+/// volume silently truncates the scan -- the worst kind of wrong, because the
+/// total still looks plausible.
+///
+/// Encoding: each run starts with a header byte whose low nibble is the byte
+/// count of the length field and whose high nibble is the byte count of the
+/// LCN offset. The offset is a *signed* delta from the previous run's LCN, so
+/// runs can go backwards on the volume. A header of zero ends the list.
+///
+/// Returns `None` on a malformed list rather than a partial one: a truncated
+/// run list would under-report sizes while looking like a complete answer.
+pub(crate) fn parse_run_list(bytes: &[u8]) -> Option<Vec<Run>> {
+    let mut runs = Vec::new();
+    let mut pos = 0usize;
+    let mut prev_lcn: i64 = 0;
+
+    loop {
+        let header = *bytes.get(pos)?;
+        if header == 0 {
+            return Some(runs);
+        }
+        let len_bytes = (header & 0x0F) as usize;
+        let off_bytes = (header >> 4) as usize;
+        // A zero-length field cannot describe a run, and either field wider
+        // than 8 bytes cannot be held in the integers below.
+        if len_bytes == 0 || len_bytes > 8 || off_bytes > 8 {
+            return None;
+        }
+        pos += 1;
+
+        let length = read_le_unsigned(bytes, pos, len_bytes)?;
+        pos += len_bytes;
+
+        let lcn = if off_bytes == 0 {
+            // No offset field: a sparse run, which holds no clusters.
+            None
+        } else {
+            let delta = read_le_signed(bytes, pos, off_bytes)?;
+            pos += off_bytes;
+            prev_lcn = prev_lcn.checked_add(delta)?;
+            if prev_lcn < 0 {
+                return None;
+            }
+            Some(prev_lcn as u64)
+        };
+
+        runs.push(Run { lcn, length });
+
+        // A run list is bounded by the attribute that holds it; this guards a
+        // list with no terminator.
+        if pos >= bytes.len() {
+            return Some(runs);
+        }
+    }
+}
+
+fn read_le_unsigned(b: &[u8], off: usize, n: usize) -> Option<u64> {
+    let s = b.get(off..off + n)?;
+    let mut v = 0u64;
+    for (i, byte) in s.iter().enumerate() {
+        v |= (*byte as u64) << (i * 8);
+    }
+    Some(v)
+}
+
+/// Little-endian, sign-extended from `n` bytes. The LCN offset is a signed
+/// delta, so a run can sit before the previous one on the volume.
+fn read_le_signed(b: &[u8], off: usize, n: usize) -> Option<i64> {
+    let s = b.get(off..off + n)?;
+    let mut v = 0u64;
+    for (i, byte) in s.iter().enumerate() {
+        v |= (*byte as u64) << (i * 8);
+    }
+    let sign_bit = 1u64 << (n * 8 - 1);
+    if v & sign_bit != 0 {
+        // Fill the unused high bytes with ones.
+        let mask = !0u64 << (n * 8);
+        v |= mask;
+    }
+    Some(v as i64)
+}
+
+/// Total clusters a run list actually occupies, ignoring sparse runs.
+///
+/// This is the number that matters for "space used": a sparse file's apparent
+/// size counts holes, its allocated size does not.
+pub(crate) fn allocated_clusters(runs: &[Run]) -> u64 {
+    runs.iter()
+        .filter(|r| r.lcn.is_some())
+        .map(|r| r.length)
+        .sum()
+}
+
+/// Byte offset of the run holding `vcn`, given the cluster size.
+///
+/// Needed to read record N of the MFT: the record's virtual offset has to be
+/// mapped through the run list to a physical one.
+pub(crate) fn vcn_to_offset(runs: &[Run], vcn: u64, cluster_size: u64) -> Option<u64> {
+    let mut base = 0u64;
+    for run in runs {
+        if vcn < base + run.length {
+            // A read inside a sparse run has no backing bytes.
+            let lcn = run.lcn?;
+            return (lcn + (vcn - base)).checked_mul(cluster_size);
+        }
+        base += run.length;
+    }
+    None
+}
+
+// --- $ATTRIBUTE_LIST ---------------------------------------------------------
+
+/// One entry of an `$ATTRIBUTE_LIST`: which attribute lives in which record.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AttrListEntry {
+    pub(crate) type_code: u32,
+    /// Record holding the attribute. Equal to the base record for attributes
+    /// that did not need to move out.
+    pub(crate) record: u64,
+}
+
+/// Parse an `$ATTRIBUTE_LIST` value.
+///
+/// A heavily fragmented file outgrows its MFT record, and NTFS moves some of
+/// its attributes into extension records. Ignoring this list means missing the
+/// `$DATA` of exactly the largest files -- the ones a disk-usage tool exists to
+/// find.
+pub(crate) fn parse_attribute_list(value: &[u8]) -> Vec<AttrListEntry> {
+    let mut out = Vec::new();
+    let mut pos = 0usize;
+    while pos + 26 <= value.len() {
+        let Some(type_code) = u32_at(value, pos) else {
+            break;
+        };
+        let Some(entry_len) = u16_at(value, pos + 4).map(usize::from) else {
+            break;
+        };
+        // Zero or backwards length would spin; anything past the value is corrupt.
+        if entry_len < 26 || pos + entry_len > value.len() {
+            break;
+        }
+        let Some(reference) = u64_at(value, pos + 16) else {
+            break;
+        };
+        out.push(AttrListEntry {
+            type_code,
+            // Low 48 bits again; the high 16 are the reuse sequence.
+            record: reference & 0x0000_FFFF_FFFF_FFFF,
+        });
+        pos += entry_len;
+    }
+    out
+}
+
+// --- hardlinks ---------------------------------------------------------------
+
+/// The `$FILE_NAME` entries that represent distinct links, from all the entries
+/// on a record.
+///
+/// A record carries one `$FILE_NAME` per link, plus a second entry for any link
+/// that also has a DOS 8.3 alias. Counting entries would double-count every
+/// file with a short name -- which on a system volume is most of them.
+///
+/// Namespace 3 (`WIN32_AND_DOS`) is a single name serving both, so it counts
+/// once; only namespace 2 (`DOS`) is a separate alias entry to drop.
+pub(crate) fn distinct_links(names: &[FileName]) -> Vec<&FileName> {
+    names.iter().filter(|f| !f.is_dos_alias()).collect()
+}
+
+/// Whether a record's bytes should be counted for this link, given how many
+/// links it has and whether this one has been seen.
+///
+/// GNU `du` charges a hardlinked file once, to whichever link it meets first.
+/// Doing the same here keeps the MFT backend's totals comparable with the
+/// enumeration backend's, which is the check that decides whether this backend
+/// is correct at all.
+pub(crate) fn should_count_link(hard_link_count: u16, already_seen: bool) -> bool {
+    if hard_link_count <= 1 {
+        // Not linked: nothing to dedupe, and the map lookup is skipped.
+        return true;
+    }
+    !already_seen
+}
+
+// --- path reconstruction -----------------------------------------------------
+
+/// Record number of the root directory. Fixed by the format.
+pub(crate) const ROOT_RECORD: u64 = 5;
+
+/// Build a path from a record number by walking parent references.
+///
+/// `name_of` returns `(name, parent)` for a record, or `None` when the record
+/// is unknown. Returns `None` when the chain does not reach the root, which
+/// happens for orphaned records on a damaged volume -- attributing their bytes
+/// to a guessed parent would silently move space between directories.
+///
+/// A cycle would otherwise hang the scan, so the walk is bounded: NTFS paths
+/// cannot nest deeper than this in practice, and a longer chain means the
+/// references are corrupt.
+pub(crate) fn build_path<F>(record: u64, name_of: F) -> Option<String>
+where
+    F: Fn(u64) -> Option<(String, u64)>,
+{
+    const MAX_DEPTH: usize = 256;
+    let mut parts: Vec<String> = Vec::new();
+    let mut current = record;
+
+    for _ in 0..MAX_DEPTH {
+        if current == ROOT_RECORD {
+            parts.reverse();
+            return Some(parts.join("\\"));
+        }
+        let (name, parent) = name_of(current)?;
+        // A record that is its own parent is corrupt, and would loop.
+        if parent == current {
+            return None;
+        }
+        parts.push(name);
+        current = parent;
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -741,6 +979,317 @@ mod tests {
             sizes.allocated_size, 8192,
             "allocated is what the volume spends, and is where a sparse or \
              compressed file differs from its apparent size"
+        );
+    }
+
+    // --- $ATTRIBUTE_LIST -----------------------------------------------------
+
+    fn attr_list_entry(type_code: u32, record: u64, name_len: u8) -> Vec<u8> {
+        let entry_len = 26 + (name_len as usize) * 2;
+        let total = entry_len.next_multiple_of(8);
+        let mut v = vec![0u8; total];
+        v[0..4].copy_from_slice(&type_code.to_le_bytes());
+        v[4..6].copy_from_slice(&(total as u16).to_le_bytes());
+        v[6] = name_len;
+        v[16..24].copy_from_slice(&record.to_le_bytes());
+        v
+    }
+
+    #[test]
+    fn parses_an_attribute_list_pointing_at_extension_records() {
+        let mut v = attr_list_entry(attr_type::DATA, 100, 0);
+        v.extend(attr_list_entry(attr_type::DATA, 101, 0));
+        let entries = parse_attribute_list(&v);
+        assert_eq!(
+            entries,
+            vec![
+                AttrListEntry {
+                    type_code: attr_type::DATA,
+                    record: 100
+                },
+                AttrListEntry {
+                    type_code: attr_type::DATA,
+                    record: 101
+                },
+            ],
+            "a fragmented file's $DATA lives across several records"
+        );
+    }
+
+    #[test]
+    fn an_attribute_list_reference_drops_the_sequence_number() {
+        let v = attr_list_entry(attr_type::DATA, 0x0003_0000_0000_0064, 0);
+        assert_eq!(parse_attribute_list(&v)[0].record, 100);
+    }
+
+    #[test]
+    fn a_zero_length_attribute_list_entry_does_not_loop_forever() {
+        let mut v = attr_list_entry(attr_type::DATA, 100, 0);
+        v[4..6].copy_from_slice(&0u16.to_le_bytes());
+        assert!(parse_attribute_list(&v).is_empty(), "must stop, not spin");
+    }
+
+    #[test]
+    fn an_attribute_list_entry_past_the_value_is_dropped() {
+        let mut v = attr_list_entry(attr_type::DATA, 100, 0);
+        v[4..6].copy_from_slice(&9999u16.to_le_bytes());
+        assert!(parse_attribute_list(&v).is_empty());
+    }
+
+    #[test]
+    fn a_truncated_attribute_list_yields_the_entries_it_could_read() {
+        let mut v = attr_list_entry(attr_type::DATA, 100, 0);
+        v.extend_from_slice(&[0u8; 8]); // not enough for a second entry
+        assert_eq!(parse_attribute_list(&v).len(), 1);
+    }
+
+    // --- hardlinks -----------------------------------------------------------
+
+    fn fname(ns: u8, name: &str) -> FileName {
+        FileName {
+            parent: 5,
+            allocated_size: 0,
+            real_size: 0,
+            namespace: ns,
+            name: name.to_string(),
+        }
+    }
+
+    #[test]
+    fn a_dos_alias_is_not_a_separate_link() {
+        let names = vec![
+            fname(namespace::WIN32, "LongFileName.txt"),
+            fname(namespace::DOS, "LONGFI~1.TXT"),
+        ];
+        assert_eq!(
+            distinct_links(&names).len(),
+            1,
+            "counting the 8.3 alias would double every file that has one"
+        );
+    }
+
+    #[test]
+    fn two_real_links_count_twice() {
+        let names = vec![
+            fname(namespace::WIN32, "original.txt"),
+            fname(namespace::WIN32, "hardlink.txt"),
+        ];
+        assert_eq!(distinct_links(&names).len(), 2);
+    }
+
+    #[test]
+    fn a_win32_and_dos_name_counts_once() {
+        let names = vec![fname(namespace::WIN32_AND_DOS, "readme")];
+        assert_eq!(
+            distinct_links(&names).len(),
+            1,
+            "namespace 3 is one name serving both, not two links"
+        );
+    }
+
+    #[test]
+    fn a_posix_name_is_a_link() {
+        let names = vec![fname(namespace::POSIX, "case.txt")];
+        assert_eq!(distinct_links(&names).len(), 1);
+    }
+
+    #[test]
+    fn an_unlinked_file_is_counted_without_consulting_the_map() {
+        // hard_link_count 1: the "already seen" answer must not matter, so the
+        // caller can skip the lookup entirely.
+        assert!(should_count_link(1, false));
+        assert!(should_count_link(1, true));
+    }
+
+    #[test]
+    fn a_hardlinked_file_is_counted_once() {
+        assert!(should_count_link(3, false), "first link seen: count it");
+        assert!(!should_count_link(3, true), "second link: already counted");
+    }
+
+    // --- path reconstruction -------------------------------------------------
+
+    /// `records[n] = (name, parent)`
+    fn lookup(records: Vec<(u64, &'static str, u64)>) -> impl Fn(u64) -> Option<(String, u64)> {
+        move |n| {
+            records
+                .iter()
+                .find(|(rec, _, _)| *rec == n)
+                .map(|(_, name, parent)| ((*name).to_string(), *parent))
+        }
+    }
+
+    #[test]
+    fn builds_a_path_by_walking_parent_references() {
+        // 5 = root, 10 = Users, 11 = alice, 12 = notes.txt
+        let f = lookup(vec![
+            (10, "Users", ROOT_RECORD),
+            (11, "alice", 10),
+            (12, "notes.txt", 11),
+        ]);
+        assert_eq!(
+            build_path(12, f).as_deref(),
+            Some("Users\\alice\\notes.txt")
+        );
+    }
+
+    #[test]
+    fn the_root_record_is_the_empty_path() {
+        let f = lookup(vec![]);
+        assert_eq!(build_path(ROOT_RECORD, f).as_deref(), Some(""));
+    }
+
+    #[test]
+    fn an_orphaned_record_has_no_path() {
+        // 12's parent 99 is not in the table, so the chain never reaches root.
+        let f = lookup(vec![(12, "orphan.txt", 99)]);
+        assert_eq!(
+            build_path(12, f),
+            None,
+            "guessing a parent would move bytes between directories"
+        );
+    }
+
+    #[test]
+    fn a_self_referencing_record_does_not_hang() {
+        let f = lookup(vec![(12, "loop", 12)]);
+        assert_eq!(build_path(12, f), None);
+    }
+
+    #[test]
+    fn a_reference_cycle_does_not_hang() {
+        let f = lookup(vec![(12, "a", 13), (13, "b", 12)]);
+        assert_eq!(build_path(12, f), None, "bounded walk, not an infinite one");
+    }
+
+    // --- run lists -----------------------------------------------------------
+
+    #[test]
+    fn decodes_a_single_run() {
+        // 0x21: 1 length byte, 2 offset bytes. Length 0x34, LCN 0x1234.
+        let runs = parse_run_list(&[0x21, 0x34, 0x34, 0x12, 0x00]).expect("should parse");
+        assert_eq!(
+            runs,
+            vec![Run {
+                lcn: Some(0x1234),
+                length: 0x34
+            }]
+        );
+    }
+
+    #[test]
+    fn a_fragmented_mft_decodes_to_several_runs() {
+        // Two runs; the second offset is a delta from the first, not absolute.
+        // 0x11 len=0x30 off=0x60  -> lcn 0x60
+        // 0x11 len=0x20 off=0x10  -> lcn 0x70
+        let runs = parse_run_list(&[0x11, 0x30, 0x60, 0x11, 0x20, 0x10, 0x00]).expect("parse");
+        assert_eq!(
+            runs,
+            vec![
+                Run {
+                    lcn: Some(0x60),
+                    length: 0x30
+                },
+                Run {
+                    lcn: Some(0x70),
+                    length: 0x20
+                },
+            ],
+            "the second LCN is the first plus the delta"
+        );
+    }
+
+    #[test]
+    fn a_negative_delta_moves_backwards_on_the_volume() {
+        // 0x11 len=0x10 off=0x40        -> lcn 0x40
+        // 0x11 len=0x10 off=0xF0 (= -16) -> lcn 0x30
+        let runs = parse_run_list(&[0x11, 0x10, 0x40, 0x11, 0x10, 0xF0, 0x00]).expect("parse");
+        assert_eq!(
+            runs[1].lcn,
+            Some(0x30),
+            "the offset is signed; treating it as unsigned would land far away"
+        );
+    }
+
+    #[test]
+    fn a_sparse_run_has_no_starting_cluster() {
+        // 0x01: 1 length byte, no offset field -> sparse.
+        let runs = parse_run_list(&[0x11, 0x10, 0x40, 0x01, 0x20, 0x00]).expect("parse");
+        assert_eq!(runs[1].lcn, None, "a hole occupies nothing");
+        assert_eq!(runs[1].length, 0x20);
+    }
+
+    #[test]
+    fn sparse_runs_do_not_count_towards_allocated_space() {
+        let runs = parse_run_list(&[0x11, 0x10, 0x40, 0x01, 0xF0, 0x00]).expect("parse");
+        assert_eq!(
+            allocated_clusters(&runs),
+            0x10,
+            "a 0xF0-cluster hole must not be charged to the file"
+        );
+    }
+
+    #[test]
+    fn an_empty_run_list_is_an_empty_list_not_an_error() {
+        assert_eq!(parse_run_list(&[0x00]), Some(vec![]));
+    }
+
+    #[test]
+    fn a_truncated_run_list_is_rejected_rather_than_partially_returned() {
+        // Header claims 2 length bytes and 2 offset bytes, but the data stops.
+        assert_eq!(
+            parse_run_list(&[0x22, 0x34]),
+            None,
+            "a partial list would under-report the size while looking complete"
+        );
+    }
+
+    #[test]
+    fn a_zero_length_field_is_rejected() {
+        // Low nibble 0 cannot describe a run length.
+        assert_eq!(parse_run_list(&[0x10, 0x40, 0x00]), None);
+    }
+
+    #[test]
+    fn a_run_list_without_a_terminator_still_returns_what_it_read() {
+        // The attribute bounds the list, so running out of bytes is not an error.
+        let runs = parse_run_list(&[0x11, 0x30, 0x60]).expect("parse");
+        assert_eq!(runs.len(), 1);
+    }
+
+    #[test]
+    fn a_delta_that_would_make_the_lcn_negative_is_rejected() {
+        // 0x11 len=0x10 off=0x80 (= -128) from a starting LCN of 0.
+        assert_eq!(parse_run_list(&[0x11, 0x10, 0x80, 0x00]), None);
+    }
+
+    #[test]
+    fn maps_a_virtual_cluster_to_its_place_on_the_volume() {
+        let runs = parse_run_list(&[0x11, 0x10, 0x40, 0x11, 0x10, 0x40, 0x00]).expect("parse");
+        // First run covers VCN 0..0x10 at LCN 0x40; second covers 0x10..0x20 at 0x80.
+        assert_eq!(vcn_to_offset(&runs, 0, 4096), Some(0x40 * 4096));
+        assert_eq!(vcn_to_offset(&runs, 5, 4096), Some(0x45 * 4096));
+        assert_eq!(
+            vcn_to_offset(&runs, 0x10, 4096),
+            Some(0x80 * 4096),
+            "the second extent must be found through the run list, not assumed \
+             to follow the first"
+        );
+    }
+
+    #[test]
+    fn a_virtual_cluster_past_the_end_has_no_offset() {
+        let runs = parse_run_list(&[0x11, 0x10, 0x40, 0x00]).expect("parse");
+        assert_eq!(vcn_to_offset(&runs, 0x99, 4096), None);
+    }
+
+    #[test]
+    fn a_virtual_cluster_inside_a_hole_has_no_offset() {
+        let runs = parse_run_list(&[0x01, 0x10, 0x11, 0x10, 0x40, 0x00]).expect("parse");
+        assert_eq!(
+            vcn_to_offset(&runs, 5, 4096),
+            None,
+            "a hole has no bytes to read"
         );
     }
 

--- a/hyperdu-core/src/platform/windows_impl/mft.rs
+++ b/hyperdu-core/src/platform/windows_impl/mft.rs
@@ -169,7 +169,8 @@ pub(crate) fn apply_fixups(rec: &mut [u8], bytes_per_sector: u32) -> bool {
     };
     for i in 0..sectors {
         let tail = (i + 1) * sector_size - 2;
-        let (Some(found), Some(orig)) = (u16_at(rec, tail), u16_at(rec, usa_off + 2 + i * 2)) else {
+        let (Some(found), Some(orig)) = (u16_at(rec, tail), u16_at(rec, usa_off + 2 + i * 2))
+        else {
             return false;
         };
         if found != seq {

--- a/hyperdu-core/src/platform/windows_impl/mft.rs
+++ b/hyperdu-core/src/platform/windows_impl/mft.rs
@@ -1,0 +1,764 @@
+//! Parsing of NTFS on-disk structures: the boot sector and MFT records.
+//!
+//! This module is pure parsing over byte slices. It opens no volume and issues
+//! no syscalls, so every case below is exercised by unit tests over synthetic
+//! records -- including the ones that are awkward to produce on a real volume
+//! (a torn write, a name that runs past the record, a zero-length attribute).
+//! Reading an actual `\\.\C:` needs administrator rights and lives in the
+//! caller.
+//!
+//! Why MFT parsing is worth the complexity: an MFT record's `$FILE_NAME`
+//! attribute carries the *parent* directory reference, so name and size join
+//! without walking the tree. The cost is one sequential read of the MFT rather
+//! than one random access per file.
+//!
+//! Offsets are named constants rather than magic numbers so a mismatch against
+//! the documented layout is greppable.
+
+// Nothing here is called from the scan yet -- `process_dir` still goes to `nt`
+// or `win32`. The parser lands first, with its tests, so that the volume I/O
+// that follows is written against something already known to be correct.
+// Remove this once the backend is wired up.
+#![allow(dead_code)]
+
+/// Signature at the head of every MFT record.
+const RECORD_SIGNATURE: &[u8; 4] = b"FILE";
+
+/// Attribute type codes. Only the ones needed for sizes are listed.
+pub(crate) mod attr_type {
+    pub(crate) const ATTRIBUTE_LIST: u32 = 0x20;
+    pub(crate) const FILE_NAME: u32 = 0x30;
+    pub(crate) const DATA: u32 = 0x80;
+    /// Terminates the attribute chain.
+    pub(crate) const END: u32 = 0xFFFF_FFFF;
+}
+
+/// `$FILE_NAME` namespaces. A file often has two entries -- a Win32 name and a
+/// DOS 8.3 name -- for the *same* link, so counting namespaces as links would
+/// double-count.
+pub(crate) mod namespace {
+    pub(crate) const POSIX: u8 = 0;
+    pub(crate) const WIN32: u8 = 1;
+    pub(crate) const DOS: u8 = 2;
+    pub(crate) const WIN32_AND_DOS: u8 = 3;
+}
+
+/// Record header flags.
+const FLAG_IN_USE: u16 = 0x0001;
+const FLAG_DIRECTORY: u16 = 0x0002;
+
+fn u16_at(b: &[u8], off: usize) -> Option<u16> {
+    Some(u16::from_le_bytes(b.get(off..off + 2)?.try_into().ok()?))
+}
+
+fn u32_at(b: &[u8], off: usize) -> Option<u32> {
+    Some(u32::from_le_bytes(b.get(off..off + 4)?.try_into().ok()?))
+}
+
+fn u64_at(b: &[u8], off: usize) -> Option<u64> {
+    Some(u64::from_le_bytes(b.get(off..off + 8)?.try_into().ok()?))
+}
+
+// --- boot sector -------------------------------------------------------------
+
+/// Geometry needed to locate and size MFT records, read from the boot sector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Geometry {
+    pub(crate) bytes_per_sector: u32,
+    pub(crate) sectors_per_cluster: u32,
+    /// Byte offset of the MFT from the start of the volume.
+    pub(crate) mft_offset: u64,
+    pub(crate) record_size: u32,
+}
+
+impl Geometry {
+    pub(crate) fn cluster_size(&self) -> u32 {
+        self.bytes_per_sector * self.sectors_per_cluster
+    }
+}
+
+/// Parse the NTFS boot sector.
+///
+/// Returns `None` for anything that is not a plausible NTFS volume rather than
+/// guessing: the caller falls back to directory enumeration, and a wrong guess
+/// here would be read as a real answer.
+pub(crate) fn parse_boot_sector(boot: &[u8]) -> Option<Geometry> {
+    if boot.len() < 84 || boot.get(3..11)? != b"NTFS    " {
+        return None;
+    }
+    let bytes_per_sector = u16_at(boot, 11)? as u32;
+    // Every other offset here assumes a power-of-two sector size.
+    if !(512..=4096).contains(&bytes_per_sector) || !bytes_per_sector.is_power_of_two() {
+        return None;
+    }
+
+    // Since Windows 10 a negative value is a base-2 shift rather than a count.
+    let sectors_per_cluster = decode_shift_or_count(*boot.get(13)? as i8, 1)?;
+    let cluster_size = bytes_per_sector.checked_mul(sectors_per_cluster)?;
+
+    let mft_lcn = u64_at(boot, 48)?;
+    let mft_offset = mft_lcn.checked_mul(cluster_size as u64)?;
+
+    let record_size = decode_shift_or_count(*boot.get(64)? as i8, cluster_size)?;
+    // A record holds at least a header and one attribute, and is not megabytes.
+    if !(48..=(1 << 20)).contains(&record_size) {
+        return None;
+    }
+
+    Some(Geometry {
+        bytes_per_sector,
+        sectors_per_cluster,
+        mft_offset,
+        record_size,
+    })
+}
+
+/// NTFS stores two fields as "a count of `unit`, or a base-2 shift when
+/// negative". Getting this wrong yields a plausible-looking but wrong geometry,
+/// so it is factored out and tested directly.
+fn decode_shift_or_count(raw: i8, unit: u32) -> Option<u32> {
+    match raw {
+        0 => None,
+        n if n < 0 => {
+            let shift = (-(n as i32)) as u32;
+            if shift > 31 {
+                return None;
+            }
+            Some(1u32 << shift)
+        }
+        n => (n as u32).checked_mul(unit),
+    }
+}
+
+// --- fixups ------------------------------------------------------------------
+
+/// Undo the update-sequence fixups an MFT record carries.
+///
+/// NTFS overwrites the last two bytes of every sector with a sequence number so
+/// a torn write is detectable, and keeps the real bytes in an array at the head
+/// of the record. Parsing without restoring them silently reads the sequence
+/// number as data, which is why this runs before anything else looks at the
+/// record.
+///
+/// Returns false when the record fails the torn-write check, in which case the
+/// record must not be trusted.
+pub(crate) fn apply_fixups(rec: &mut [u8], bytes_per_sector: u32) -> bool {
+    let (Some(usa_off), Some(usa_count)) = (
+        u16_at(rec, 4).map(usize::from),
+        u16_at(rec, 6).map(usize::from),
+    ) else {
+        return false;
+    };
+    // usa_count counts the sequence number plus one entry per sector.
+    if usa_count == 0 {
+        return false;
+    }
+    let sectors = usa_count - 1;
+    let sector_size = bytes_per_sector as usize;
+    if sectors == 0 || sector_size < 2 || rec.len() < sectors * sector_size {
+        return false;
+    }
+    // The array itself must fit inside the record.
+    match usa_off.checked_add(usa_count * 2) {
+        Some(end) if end <= rec.len() => {}
+        _ => return false,
+    }
+
+    let Some(seq) = u16_at(rec, usa_off) else {
+        return false;
+    };
+    for i in 0..sectors {
+        let tail = (i + 1) * sector_size - 2;
+        let (Some(found), Some(orig)) = (u16_at(rec, tail), u16_at(rec, usa_off + 2 + i * 2)) else {
+            return false;
+        };
+        if found != seq {
+            // Torn write, or not the record we think it is.
+            return false;
+        }
+        rec[tail..tail + 2].copy_from_slice(&orig.to_le_bytes());
+    }
+    true
+}
+
+// --- record header -----------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RecordHeader {
+    pub(crate) first_attr_offset: usize,
+    pub(crate) used_size: u32,
+    pub(crate) in_use: bool,
+    pub(crate) is_directory: bool,
+    pub(crate) hard_link_count: u16,
+}
+
+/// Parse an MFT record header. Call [`apply_fixups`] first.
+pub(crate) fn parse_record_header(rec: &[u8]) -> Option<RecordHeader> {
+    if rec.len() < 48 || rec.get(0..4)? != RECORD_SIGNATURE {
+        return None;
+    }
+    let hard_link_count = u16_at(rec, 18)?;
+    let first_attr_offset = u16_at(rec, 20)? as usize;
+    let flags = u16_at(rec, 22)?;
+    let used_size = u32_at(rec, 24)?;
+
+    // An offset outside the record, or a used size larger than the record,
+    // means this is not the record it claims to be.
+    if first_attr_offset < 48 || first_attr_offset >= rec.len() {
+        return None;
+    }
+    if (used_size as usize) > rec.len() {
+        return None;
+    }
+
+    Some(RecordHeader {
+        first_attr_offset,
+        used_size,
+        in_use: flags & FLAG_IN_USE != 0,
+        is_directory: flags & FLAG_DIRECTORY != 0,
+        hard_link_count,
+    })
+}
+
+// --- attributes --------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AttrHeader {
+    pub(crate) type_code: u32,
+    /// Offset of this attribute within the record.
+    pub(crate) pos: usize,
+    pub(crate) total_length: usize,
+    pub(crate) non_resident: bool,
+    /// Offset of the value within the record, for resident attributes.
+    pub(crate) value_offset: usize,
+    pub(crate) value_length: usize,
+}
+
+/// Walks the attribute chain of a record.
+///
+/// Stops at the end marker, at the used size, or at the first malformed header.
+/// A zero or backwards length would otherwise loop forever on a corrupt record,
+/// and the MFT of a failing disk is exactly where that shows up.
+pub(crate) struct Attributes<'a> {
+    rec: &'a [u8],
+    pos: usize,
+    limit: usize,
+    done: bool,
+}
+
+impl<'a> Attributes<'a> {
+    pub(crate) fn new(rec: &'a [u8], header: &RecordHeader) -> Self {
+        Self {
+            rec,
+            pos: header.first_attr_offset,
+            limit: (header.used_size as usize).min(rec.len()),
+            done: false,
+        }
+    }
+}
+
+impl Iterator for Attributes<'_> {
+    type Item = AttrHeader;
+
+    fn next(&mut self) -> Option<AttrHeader> {
+        if self.done || self.pos + 8 > self.limit {
+            return None;
+        }
+        let type_code = u32_at(self.rec, self.pos)?;
+        if type_code == attr_type::END {
+            self.done = true;
+            return None;
+        }
+        let total_length = u32_at(self.rec, self.pos + 4)? as usize;
+        // Zero-length would spin; a length past the record is corrupt.
+        if total_length < 16 || self.pos + total_length > self.limit {
+            self.done = true;
+            return None;
+        }
+        let non_resident = *self.rec.get(self.pos + 8)? != 0;
+
+        let (value_offset, value_length) = if non_resident {
+            (0, 0)
+        } else {
+            let off = u16_at(self.rec, self.pos + 20)? as usize;
+            let len = u32_at(self.rec, self.pos + 16)? as usize;
+            // The value must lie inside this attribute.
+            if off < 16 || off + len > total_length {
+                self.done = true;
+                return None;
+            }
+            (self.pos + off, len)
+        };
+
+        let out = AttrHeader {
+            type_code,
+            pos: self.pos,
+            total_length,
+            non_resident,
+            value_offset,
+            value_length,
+        };
+        self.pos += total_length;
+        Some(out)
+    }
+}
+
+// --- $FILE_NAME --------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FileName {
+    /// Record number of the parent directory. The sequence number is dropped;
+    /// only the low 48 bits identify the record.
+    pub(crate) parent: u64,
+    pub(crate) allocated_size: u64,
+    pub(crate) real_size: u64,
+    pub(crate) namespace: u8,
+    pub(crate) name: String,
+}
+
+impl FileName {
+    /// True when this entry is a DOS 8.3 alias of another `$FILE_NAME` on the
+    /// same record. Counting it as a link would double-count the file.
+    pub(crate) fn is_dos_alias(&self) -> bool {
+        self.namespace == namespace::DOS
+    }
+}
+
+/// Parse a `$FILE_NAME` attribute value.
+pub(crate) fn parse_file_name(value: &[u8]) -> Option<FileName> {
+    if value.len() < 66 {
+        return None;
+    }
+    // Low 48 bits are the record number; the high 16 are a reuse sequence.
+    let parent = u64_at(value, 0)? & 0x0000_FFFF_FFFF_FFFF;
+    let allocated_size = u64_at(value, 40)?;
+    let real_size = u64_at(value, 48)?;
+    let name_len = *value.get(64)? as usize;
+    let ns = *value.get(65)?;
+
+    let name_bytes = value.get(66..66 + name_len * 2)?;
+    let units: Vec<u16> = name_bytes
+        .chunks_exact(2)
+        .map(|c| u16::from_le_bytes([c[0], c[1]]))
+        .collect();
+    // Lossy on purpose: an unpaired surrogate on disk must not cost the whole
+    // record, and the name is only used for display and grouping.
+    let name = String::from_utf16_lossy(&units);
+
+    Some(FileName {
+        parent,
+        allocated_size,
+        real_size,
+        namespace: ns,
+        name,
+    })
+}
+
+// --- $DATA -------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(crate) struct DataSizes {
+    pub(crate) real_size: u64,
+    pub(crate) allocated_size: u64,
+}
+
+/// Sizes from a `$DATA` attribute.
+///
+/// `$FILE_NAME` also carries sizes, but they are only refreshed when the name is
+/// written, so a growing file reports a stale size there. `$DATA` is the
+/// authority; `$FILE_NAME` is the fallback for records where `$DATA` lives in an
+/// extension record.
+pub(crate) fn parse_data_sizes(rec: &[u8], attr: &AttrHeader) -> Option<DataSizes> {
+    if !attr.non_resident {
+        // A small file lives inside the record and occupies no clusters of its
+        // own, so reporting the cluster size here would overcount every tiny
+        // file on the volume.
+        return Some(DataSizes {
+            real_size: attr.value_length as u64,
+            allocated_size: attr.value_length as u64,
+        });
+    }
+    // Non-resident header: allocated at 0x28, real at 0x30. For compressed or
+    // sparse data the allocated size is what the volume actually spends, which
+    // is the number `du`-style tools want.
+    Some(DataSizes {
+        allocated_size: u64_at(rec, attr.pos + 0x28)?,
+        real_size: u64_at(rec, attr.pos + 0x30)?,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- boot sector ---------------------------------------------------------
+
+    fn boot_sector(bps: u16, spc: i8, mft_lcn: u64, cpr: i8) -> Vec<u8> {
+        let mut b = vec![0u8; 512];
+        b[3..11].copy_from_slice(b"NTFS    ");
+        b[11..13].copy_from_slice(&bps.to_le_bytes());
+        b[13] = spc as u8;
+        b[48..56].copy_from_slice(&mft_lcn.to_le_bytes());
+        b[64] = cpr as u8;
+        b
+    }
+
+    #[test]
+    fn parses_a_typical_ntfs_boot_sector() {
+        // 512 B/sector, 8 sectors/cluster = 4 KiB clusters, 1 KiB records.
+        let g = parse_boot_sector(&boot_sector(512, 8, 786432, -10)).expect("should parse");
+        assert_eq!(g.bytes_per_sector, 512);
+        assert_eq!(g.sectors_per_cluster, 8);
+        assert_eq!(g.cluster_size(), 4096);
+        assert_eq!(g.record_size, 1024);
+        assert_eq!(g.mft_offset, 786432 * 4096);
+    }
+
+    #[test]
+    fn rejects_a_non_ntfs_volume() {
+        let mut b = boot_sector(512, 8, 100, -10);
+        b[3..11].copy_from_slice(b"FAT32   ");
+        assert!(parse_boot_sector(&b).is_none());
+    }
+
+    #[test]
+    fn rejects_an_implausible_sector_size() {
+        assert!(parse_boot_sector(&boot_sector(999, 8, 100, -10)).is_none());
+        assert!(parse_boot_sector(&boot_sector(0, 8, 100, -10)).is_none());
+    }
+
+    #[test]
+    fn rejects_a_zero_sectors_per_cluster() {
+        assert!(parse_boot_sector(&boot_sector(512, 0, 100, -10)).is_none());
+    }
+
+    #[test]
+    fn handles_the_shift_encoding_for_large_clusters() {
+        // -12 means 2^12 sectors per cluster, not "12 of them".
+        let g = parse_boot_sector(&boot_sector(512, -12, 0, -10)).expect("should parse");
+        assert_eq!(g.sectors_per_cluster, 4096);
+    }
+
+    #[test]
+    fn decodes_a_count_and_a_shift_differently() {
+        assert_eq!(decode_shift_or_count(8, 1), Some(8));
+        assert_eq!(decode_shift_or_count(-10, 1), Some(1024));
+        assert_eq!(decode_shift_or_count(0, 1), None);
+        assert_eq!(decode_shift_or_count(-99, 1), None, "shift out of range");
+    }
+
+    #[test]
+    fn rejects_a_truncated_boot_sector() {
+        assert!(parse_boot_sector(&[0u8; 32]).is_none());
+    }
+
+    // --- fixups --------------------------------------------------------------
+
+    /// A two-sector record whose sector tails hold the sequence number, with the
+    /// real bytes stashed in the update-sequence array.
+    fn record_with_fixups(sector_size: usize, seq: u16, originals: [u16; 2]) -> Vec<u8> {
+        let mut r = vec![0u8; sector_size * 2];
+        r[0..4].copy_from_slice(RECORD_SIGNATURE);
+        let usa_off = 48usize;
+        r[4..6].copy_from_slice(&(usa_off as u16).to_le_bytes());
+        r[6..8].copy_from_slice(&3u16.to_le_bytes()); // seq + 2 sectors
+        r[usa_off..usa_off + 2].copy_from_slice(&seq.to_le_bytes());
+        r[usa_off + 2..usa_off + 4].copy_from_slice(&originals[0].to_le_bytes());
+        r[usa_off + 4..usa_off + 6].copy_from_slice(&originals[1].to_le_bytes());
+        for i in 0..2 {
+            let tail = (i + 1) * sector_size - 2;
+            r[tail..tail + 2].copy_from_slice(&seq.to_le_bytes());
+        }
+        r
+    }
+
+    #[test]
+    fn fixups_restore_the_bytes_the_sequence_number_replaced() {
+        let mut r = record_with_fixups(512, 0xAABB, [0x1234, 0x5678]);
+        assert!(apply_fixups(&mut r, 512));
+        assert_eq!(u16_at(&r, 510), Some(0x1234));
+        assert_eq!(u16_at(&r, 1022), Some(0x5678));
+    }
+
+    #[test]
+    fn a_torn_write_is_rejected() {
+        let mut r = record_with_fixups(512, 0xAABB, [0x1234, 0x5678]);
+        // Second sector never reached the disk: its tail holds an older sequence.
+        r[1022..1024].copy_from_slice(&0x0001u16.to_le_bytes());
+        assert!(!apply_fixups(&mut r, 512), "must not trust a torn record");
+    }
+
+    #[test]
+    fn a_fixup_array_pointing_outside_the_record_is_rejected() {
+        let mut r = record_with_fixups(512, 0xAABB, [0x1234, 0x5678]);
+        r[4..6].copy_from_slice(&60000u16.to_le_bytes());
+        assert!(!apply_fixups(&mut r, 512));
+    }
+
+    #[test]
+    fn a_zero_usa_count_is_rejected() {
+        let mut r = record_with_fixups(512, 0xAABB, [0x1234, 0x5678]);
+        r[6..8].copy_from_slice(&0u16.to_le_bytes());
+        assert!(!apply_fixups(&mut r, 512));
+    }
+
+    // --- record header -------------------------------------------------------
+
+    fn record_header_bytes(flags: u16, first_attr: u16, used: u32, links: u16) -> Vec<u8> {
+        let mut r = vec![0u8; 1024];
+        r[0..4].copy_from_slice(RECORD_SIGNATURE);
+        r[18..20].copy_from_slice(&links.to_le_bytes());
+        r[20..22].copy_from_slice(&first_attr.to_le_bytes());
+        r[22..24].copy_from_slice(&flags.to_le_bytes());
+        r[24..28].copy_from_slice(&used.to_le_bytes());
+        r
+    }
+
+    #[test]
+    fn parses_a_file_record_header() {
+        let r = record_header_bytes(FLAG_IN_USE, 56, 400, 1);
+        let h = parse_record_header(&r).expect("should parse");
+        assert!(h.in_use);
+        assert!(!h.is_directory);
+        assert_eq!(h.first_attr_offset, 56);
+        assert_eq!(h.used_size, 400);
+        assert_eq!(h.hard_link_count, 1);
+    }
+
+    #[test]
+    fn recognises_a_directory_record() {
+        let r = record_header_bytes(FLAG_IN_USE | FLAG_DIRECTORY, 56, 400, 1);
+        assert!(parse_record_header(&r).expect("should parse").is_directory);
+    }
+
+    #[test]
+    fn recognises_a_deleted_record() {
+        let r = record_header_bytes(0, 56, 400, 1);
+        assert!(!parse_record_header(&r).expect("should parse").in_use);
+    }
+
+    #[test]
+    fn rejects_a_record_without_the_signature() {
+        let mut r = record_header_bytes(FLAG_IN_USE, 56, 400, 1);
+        r[0..4].copy_from_slice(b"BAAD");
+        assert!(parse_record_header(&r).is_none());
+    }
+
+    #[test]
+    fn rejects_a_first_attribute_offset_outside_the_record() {
+        let r = record_header_bytes(FLAG_IN_USE, 60000, 400, 1);
+        assert!(parse_record_header(&r).is_none());
+    }
+
+    #[test]
+    fn rejects_a_used_size_larger_than_the_record() {
+        let r = record_header_bytes(FLAG_IN_USE, 56, 99999, 1);
+        assert!(parse_record_header(&r).is_none());
+    }
+
+    // --- attributes ----------------------------------------------------------
+
+    /// Append a resident attribute; returns the next write position.
+    fn push_resident(r: &mut [u8], pos: usize, type_code: u32, value: &[u8]) -> usize {
+        let value_off = 24usize;
+        let total = (value_off + value.len()).next_multiple_of(8);
+        r[pos..pos + 4].copy_from_slice(&type_code.to_le_bytes());
+        r[pos + 4..pos + 8].copy_from_slice(&(total as u32).to_le_bytes());
+        r[pos + 8] = 0; // resident
+        r[pos + 16..pos + 20].copy_from_slice(&(value.len() as u32).to_le_bytes());
+        r[pos + 20..pos + 22].copy_from_slice(&(value_off as u16).to_le_bytes());
+        r[pos + value_off..pos + value_off + value.len()].copy_from_slice(value);
+        pos + total
+    }
+
+    fn end_marker(r: &mut [u8], pos: usize) {
+        r[pos..pos + 4].copy_from_slice(&attr_type::END.to_le_bytes());
+    }
+
+    #[test]
+    fn walks_the_attribute_chain() {
+        let mut r = record_header_bytes(FLAG_IN_USE, 56, 1024, 1);
+        let mut p = 56;
+        p = push_resident(&mut r, p, attr_type::FILE_NAME, &[0u8; 80]);
+        p = push_resident(&mut r, p, attr_type::DATA, &[1u8; 16]);
+        end_marker(&mut r, p);
+        let h = parse_record_header(&r).expect("header");
+        let kinds: Vec<u32> = Attributes::new(&r, &h).map(|a| a.type_code).collect();
+        assert_eq!(kinds, vec![attr_type::FILE_NAME, attr_type::DATA]);
+    }
+
+    #[test]
+    fn a_zero_length_attribute_does_not_loop_forever() {
+        let mut r = record_header_bytes(FLAG_IN_USE, 56, 1024, 1);
+        r[56..60].copy_from_slice(&attr_type::DATA.to_le_bytes());
+        r[60..64].copy_from_slice(&0u32.to_le_bytes());
+        let h = parse_record_header(&r).expect("header");
+        assert_eq!(Attributes::new(&r, &h).count(), 0, "must stop, not spin");
+    }
+
+    #[test]
+    fn an_attribute_running_past_the_record_is_dropped() {
+        let mut r = record_header_bytes(FLAG_IN_USE, 56, 1024, 1);
+        r[56..60].copy_from_slice(&attr_type::DATA.to_le_bytes());
+        r[60..64].copy_from_slice(&99999u32.to_le_bytes());
+        let h = parse_record_header(&r).expect("header");
+        assert_eq!(Attributes::new(&r, &h).count(), 0);
+    }
+
+    #[test]
+    fn attributes_stop_at_the_used_size_not_the_record_size() {
+        // The first attribute occupies 56..160 (24-byte header + 80-byte value,
+        // padded to 8). used_size is set to end exactly there, so the second
+        // attribute lies beyond it.
+        let mut r = record_header_bytes(FLAG_IN_USE, 56, 160, 1);
+        let mut p = 56;
+        p = push_resident(&mut r, p, attr_type::FILE_NAME, &[0u8; 80]);
+        assert_eq!(p, 160, "fixture assumption: first attribute ends at 160");
+        // Starts past used_size: stale bytes from a previous, larger record.
+        push_resident(&mut r, p, attr_type::DATA, &[1u8; 16]);
+        let h = parse_record_header(&r).expect("header");
+        let kinds: Vec<u32> = Attributes::new(&r, &h).map(|a| a.type_code).collect();
+        assert_eq!(kinds, vec![attr_type::FILE_NAME]);
+    }
+
+    #[test]
+    fn an_attribute_list_is_reported_so_the_caller_can_follow_it() {
+        // A file with many fragments keeps some attributes in extension
+        // records. Silently ignoring $ATTRIBUTE_LIST would undercount it.
+        let mut r = record_header_bytes(FLAG_IN_USE, 56, 1024, 1);
+        let mut p = 56;
+        p = push_resident(&mut r, p, attr_type::ATTRIBUTE_LIST, &[0u8; 32]);
+        end_marker(&mut r, p);
+        let h = parse_record_header(&r).expect("header");
+        let kinds: Vec<u32> = Attributes::new(&r, &h).map(|a| a.type_code).collect();
+        assert_eq!(kinds, vec![attr_type::ATTRIBUTE_LIST]);
+    }
+
+    // --- $FILE_NAME ----------------------------------------------------------
+
+    fn file_name_value(parent: u64, alloc: u64, real: u64, ns: u8, name: &str) -> Vec<u8> {
+        let units: Vec<u16> = name.encode_utf16().collect();
+        let mut v = vec![0u8; 66 + units.len() * 2];
+        v[0..8].copy_from_slice(&parent.to_le_bytes());
+        v[40..48].copy_from_slice(&alloc.to_le_bytes());
+        v[48..56].copy_from_slice(&real.to_le_bytes());
+        v[64] = units.len() as u8;
+        v[65] = ns;
+        for (i, u) in units.iter().enumerate() {
+            v[66 + i * 2..68 + i * 2].copy_from_slice(&u.to_le_bytes());
+        }
+        v
+    }
+
+    #[test]
+    fn parses_a_file_name_attribute() {
+        let v = file_name_value(5, 4096, 1234, namespace::WIN32, "example.txt");
+        let f = parse_file_name(&v).expect("should parse");
+        assert_eq!(f.parent, 5);
+        assert_eq!(f.allocated_size, 4096);
+        assert_eq!(f.real_size, 1234);
+        assert_eq!(f.name, "example.txt");
+        assert!(!f.is_dos_alias());
+    }
+
+    #[test]
+    fn the_parent_reference_drops_the_sequence_number() {
+        // The high 16 bits are a reuse counter, not part of the record number.
+        let v = file_name_value(0x0007_0000_0000_0005, 0, 0, namespace::WIN32, "a");
+        assert_eq!(parse_file_name(&v).expect("parse").parent, 5);
+    }
+
+    #[test]
+    fn a_dos_alias_is_recognised() {
+        let v = file_name_value(5, 0, 0, namespace::DOS, "EXAMPL~1.TXT");
+        assert!(parse_file_name(&v).expect("parse").is_dos_alias());
+    }
+
+    #[test]
+    fn a_win32_and_dos_entry_is_not_an_alias() {
+        // Namespace 3 means one name serves both, so it is a real link.
+        let v = file_name_value(5, 0, 0, namespace::WIN32_AND_DOS, "readme");
+        assert!(!parse_file_name(&v).expect("parse").is_dos_alias());
+        let p = file_name_value(5, 0, 0, namespace::POSIX, "readme");
+        assert!(!parse_file_name(&p).expect("parse").is_dos_alias());
+    }
+
+    #[test]
+    fn a_name_running_past_the_attribute_is_rejected() {
+        let mut v = file_name_value(5, 0, 0, namespace::WIN32, "abc");
+        v[64] = 200; // claims 200 characters
+        assert!(parse_file_name(&v).is_none());
+    }
+
+    #[test]
+    fn a_truncated_file_name_attribute_is_rejected() {
+        assert!(parse_file_name(&[0u8; 20]).is_none());
+    }
+
+    #[test]
+    fn a_unicode_name_survives_the_round_trip() {
+        let v = file_name_value(5, 0, 0, namespace::WIN32, "日本語のファイル.txt");
+        assert_eq!(
+            parse_file_name(&v).expect("parse").name,
+            "日本語のファイル.txt"
+        );
+    }
+
+    // --- $DATA ---------------------------------------------------------------
+
+    #[test]
+    fn a_resident_data_attribute_occupies_no_clusters() {
+        let mut r = record_header_bytes(FLAG_IN_USE, 56, 1024, 1);
+        let p = push_resident(&mut r, 56, attr_type::DATA, &[7u8; 100]);
+        end_marker(&mut r, p);
+        let h = parse_record_header(&r).expect("header");
+        let attr = Attributes::new(&r, &h).next().expect("one attribute");
+        let sizes = parse_data_sizes(&r, &attr).expect("sizes");
+        assert_eq!(sizes.real_size, 100);
+        assert_eq!(
+            sizes.allocated_size, 100,
+            "a small file lives in the record; charging it a cluster would \
+             overcount every tiny file on the volume"
+        );
+    }
+
+    #[test]
+    fn a_non_resident_data_attribute_reports_allocated_and_real_sizes() {
+        let mut r = record_header_bytes(FLAG_IN_USE, 56, 1024, 1);
+        let pos = 56usize;
+        r[pos..pos + 4].copy_from_slice(&attr_type::DATA.to_le_bytes());
+        r[pos + 4..pos + 8].copy_from_slice(&72u32.to_le_bytes());
+        r[pos + 8] = 1; // non-resident
+        r[pos + 0x28..pos + 0x30].copy_from_slice(&8192u64.to_le_bytes());
+        r[pos + 0x30..pos + 0x38].copy_from_slice(&5000u64.to_le_bytes());
+        end_marker(&mut r, pos + 72);
+        let h = parse_record_header(&r).expect("header");
+        let attr = Attributes::new(&r, &h).next().expect("one attribute");
+        let sizes = parse_data_sizes(&r, &attr).expect("sizes");
+        assert_eq!(sizes.real_size, 5000);
+        assert_eq!(
+            sizes.allocated_size, 8192,
+            "allocated is what the volume spends, and is where a sparse or \
+             compressed file differs from its apparent size"
+        );
+    }
+
+    #[test]
+    fn a_sparse_file_allocates_less_than_it_claims() {
+        let mut r = record_header_bytes(FLAG_IN_USE, 56, 1024, 1);
+        let pos = 56usize;
+        r[pos..pos + 4].copy_from_slice(&attr_type::DATA.to_le_bytes());
+        r[pos + 4..pos + 8].copy_from_slice(&72u32.to_le_bytes());
+        r[pos + 8] = 1;
+        r[pos + 0x28..pos + 0x30].copy_from_slice(&4096u64.to_le_bytes());
+        r[pos + 0x30..pos + 0x38].copy_from_slice(&(1u64 << 30).to_le_bytes());
+        end_marker(&mut r, pos + 72);
+        let h = parse_record_header(&r).expect("header");
+        let attr = Attributes::new(&r, &h).next().expect("one attribute");
+        let sizes = parse_data_sizes(&r, &attr).expect("sizes");
+        assert!(
+            sizes.allocated_size < sizes.real_size,
+            "a 1 GiB sparse file holding one cluster must not be counted as 1 GiB"
+        );
+    }
+}

--- a/hyperdu-core/src/platform/windows_impl/mft_reader.rs
+++ b/hyperdu-core/src/platform/windows_impl/mft_reader.rs
@@ -32,6 +32,14 @@ pub(crate) trait VolumeSource {
     fn read_at(&mut self, offset: u64, buf: &mut [u8]) -> bool;
 }
 
+/// Lets a caller keep ownership of the volume while the reader borrows it, so
+/// the sector size can be narrowed after the geometry is known.
+impl<S: VolumeSource + ?Sized> VolumeSource for &mut S {
+    fn read_at(&mut self, offset: u64, buf: &mut [u8]) -> bool {
+        (**self).read_at(offset, buf)
+    }
+}
+
 /// A record's identity and sizes, as the scan needs them.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Entry {

--- a/hyperdu-core/src/platform/windows_impl/mft_reader.rs
+++ b/hyperdu-core/src/platform/windows_impl/mft_reader.rs
@@ -211,6 +211,174 @@ impl<S: VolumeSource> MftReader<S> {
     }
 }
 
+// --- the real volume ---------------------------------------------------------
+
+/// A volume opened for reading, as `\\.\C:`.
+///
+/// Opening one needs administrator rights, so [`WindowsVolume::open`] returns
+/// `None` for an unelevated process and the caller falls back to directory
+/// enumeration. That failure is expected, not exceptional: most runs will not
+/// be elevated.
+#[cfg(windows)]
+pub(crate) struct WindowsVolume {
+    handle: windows::Win32::Foundation::HANDLE,
+    /// Reads on a volume handle must be aligned to the sector size and a whole
+    /// number of sectors long. MFT records are not, so reads are widened to
+    /// the enclosing sectors and the wanted bytes copied out.
+    sector: u64,
+}
+
+#[cfg(windows)]
+impl WindowsVolume {
+    /// Open `drive` (a single letter, as in `C`) for reading.
+    ///
+    /// Returns `None` when the process is not elevated, the drive does not
+    /// exist, or the handle cannot be opened for any other reason. All three
+    /// mean the same thing to the caller: use the enumeration backend.
+    pub(crate) fn open(drive: char) -> Option<Self> {
+        use windows::{
+            core::PCWSTR,
+            Win32::{
+                Foundation::{GENERIC_READ, INVALID_HANDLE_VALUE},
+                Storage::FileSystem::{
+                    CreateFileW, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, FILE_SHARE_WRITE,
+                    OPEN_EXISTING,
+                },
+            },
+        };
+
+        if !drive.is_ascii_alphabetic() {
+            return None;
+        }
+        // \\.\C: -- the volume itself, not a file on it.
+        let path: Vec<u16> = format!(r"\\.\{}:", drive.to_ascii_uppercase())
+            .encode_utf16()
+            .chain(std::iter::once(0))
+            .collect();
+
+        let handle = unsafe {
+            CreateFileW(
+                PCWSTR(path.as_ptr()),
+                GENERIC_READ.0,
+                // The volume is mounted and in use; without sharing, the open
+                // fails on every system volume.
+                FILE_SHARE_READ | FILE_SHARE_WRITE,
+                None,
+                OPEN_EXISTING,
+                FILE_ATTRIBUTE_NORMAL,
+                None,
+            )
+        }
+        .ok()?;
+
+        if handle == INVALID_HANDLE_VALUE {
+            return None;
+        }
+
+        // 512 covers every NTFS volume in practice; a 4K-native disk reports
+        // 4096 and the boot sector will say so. Reads are widened to whichever
+        // is larger, so starting conservative is safe.
+        Some(Self {
+            handle,
+            sector: 4096,
+        })
+    }
+
+    /// Narrow the alignment once the boot sector has been parsed, so reads stop
+    /// fetching more than they need.
+    pub(crate) fn set_sector_size(&mut self, bytes: u32) {
+        if bytes >= 512 && bytes.is_power_of_two() {
+            self.sector = bytes as u64;
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsVolume {
+    fn drop(&mut self) {
+        use windows::Win32::Foundation::CloseHandle;
+        unsafe {
+            let _ = CloseHandle(self.handle);
+        }
+    }
+}
+
+#[cfg(windows)]
+impl VolumeSource for WindowsVolume {
+    fn read_at(&mut self, offset: u64, buf: &mut [u8]) -> bool {
+        use windows::Win32::{
+            Storage::FileSystem::{ReadFile, SetFilePointerEx, FILE_BEGIN},
+            System::IO::OVERLAPPED,
+        };
+
+        // Widen to sector boundaries: a volume handle rejects anything else.
+        let start = offset - (offset % self.sector);
+        let end = (offset + buf.len() as u64).next_multiple_of(self.sector);
+        let span = (end - start) as usize;
+
+        let mut scratch = vec![0u8; span];
+        unsafe {
+            if SetFilePointerEx(self.handle, start as i64, None, FILE_BEGIN).is_err() {
+                return false;
+            }
+            let mut read = 0u32;
+            if ReadFile(
+                self.handle,
+                Some(scratch.as_mut_slice()),
+                Some(&mut read),
+                None::<*mut OVERLAPPED>,
+            )
+            .is_err()
+            {
+                return false;
+            }
+            if (read as usize) < span {
+                return false;
+            }
+        }
+
+        let within = (offset - start) as usize;
+        let Some(slice) = scratch.get(within..within + buf.len()) else {
+            return false;
+        };
+        buf.copy_from_slice(slice);
+        true
+    }
+}
+
+/// Whether this process can open a volume handle at all.
+///
+/// Checked before attempting, so the caller can say "needs administrator
+/// rights" rather than reporting an access-denied error from deep inside the
+/// scan.
+#[cfg(windows)]
+pub(crate) fn is_elevated() -> bool {
+    use windows::Win32::{
+        Foundation::{CloseHandle, HANDLE},
+        Security::{GetTokenInformation, TokenElevation, TOKEN_ELEVATION, TOKEN_QUERY},
+        System::Threading::{GetCurrentProcess, OpenProcessToken},
+    };
+
+    unsafe {
+        let mut token = HANDLE::default();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token).is_err() {
+            return false;
+        }
+        let mut elevation = TOKEN_ELEVATION::default();
+        let mut size = 0u32;
+        let ok = GetTokenInformation(
+            token,
+            TokenElevation,
+            Some(&mut elevation as *mut _ as *mut _),
+            std::mem::size_of::<TOKEN_ELEVATION>() as u32,
+            &mut size,
+        )
+        .is_ok();
+        let _ = CloseHandle(token);
+        ok && elevation.TokenIsElevated != 0
+    }
+}
+
 /// Byte offset of a non-resident attribute's run list within the record.
 ///
 /// The offset lives at 0x20 of the attribute header and is relative to the
@@ -549,6 +717,33 @@ mod tests {
             3,
             "dedupe needs this, and it is free here"
         );
+    }
+
+    // --- the real volume -----------------------------------------------------
+    //
+    // These do not assert on the volume's contents -- that needs elevation, and
+    // a test that only runs when elevated is a test that mostly does not run.
+    // What they do pin down is the branch every unelevated run takes.
+
+    #[cfg(windows)]
+    #[test]
+    fn opening_a_volume_agrees_with_the_elevation_check() {
+        // The two must not disagree: reporting "needs administrator rights"
+        // while the open would have worked, or vice versa, sends the caller
+        // down the wrong path.
+        let elevated = is_elevated();
+        let opened = WindowsVolume::open('C').is_some();
+        assert!(
+            !opened || elevated,
+            "a volume opened without elevation means the check is wrong"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn an_invalid_drive_letter_is_refused_without_touching_the_disk() {
+        assert!(WindowsVolume::open('1').is_none());
+        assert!(WindowsVolume::open('/').is_none());
     }
 
     #[test]

--- a/hyperdu-core/src/platform/windows_impl/mft_reader.rs
+++ b/hyperdu-core/src/platform/windows_impl/mft_reader.rs
@@ -154,7 +154,8 @@ impl<S: VolumeSource> MftReader<S> {
         for attr in Attributes::new(&rec, &header) {
             match attr.type_code {
                 attr_type::FILE_NAME if !attr.non_resident => {
-                    let value = rec.get(attr.value_offset..attr.value_offset + attr.value_length)?;
+                    let value =
+                        rec.get(attr.value_offset..attr.value_offset + attr.value_length)?;
                     if let Some(f) = parse_file_name(value) {
                         names.push(f);
                     }
@@ -438,8 +439,10 @@ mod tests {
 
     #[test]
     fn reads_a_file_record_end_to_end() {
-        let records =
-            with_metadata_records(vec![file_record(ROOT_RECORD, "notes.txt", 8192, 5000, 1)], 8);
+        let records = with_metadata_records(
+            vec![file_record(ROOT_RECORD, "notes.txt", 8192, 5000, 1)],
+            8,
+        );
         let mut reader = MftReader::open(volume(records)).expect("open");
         let e = reader.entry(16).expect("record 16 is the file");
         assert_eq!(e.name, "notes.txt");

--- a/hyperdu-core/src/platform/windows_impl/mft_reader.rs
+++ b/hyperdu-core/src/platform/windows_impl/mft_reader.rs
@@ -1,0 +1,595 @@
+//! Reading MFT records off a volume, on top of the parsing in [`super::mft`].
+//!
+//! The volume sits behind a trait rather than a file handle, for one reason: a
+//! real `\\.\C:` needs administrator rights, so a test that opened one could
+//! only run on an elevated machine and would be skipped everywhere else. With
+//! the source abstracted, the tests below build a synthetic NTFS volume in
+//! memory and exercise the whole path -- boot sector, `$MFT` run list, record
+//! iteration, name and size extraction -- with no privileges at all.
+//!
+//! What still needs a real volume is the last mile: that Windows hands back the
+//! bytes we expect. Everything above that is settled here.
+
+// Nothing here is called from the scan yet -- `process_dir` still goes to `nt`
+// or `win32`. The reader lands with its tests first, so the volume handle that
+// follows is written against something already known to work. Remove this once
+// the backend is wired up.
+#![allow(dead_code)]
+
+use std::collections::HashMap;
+
+use super::mft::{
+    allocated_clusters, apply_fixups, attr_type, build_path, distinct_links, namespace,
+    parse_boot_sector, parse_data_sizes, parse_file_name, parse_record_header, parse_run_list,
+    vcn_to_offset, Attributes, DataSizes, FileName, Geometry, Run,
+};
+
+/// Somewhere MFT bytes can be read from: a volume handle in production, a
+/// `Vec<u8>` in tests.
+pub(crate) trait VolumeSource {
+    /// Fill `buf` from `offset`. Returns false when the range is not readable,
+    /// which the caller treats as the end of usable data rather than retrying.
+    fn read_at(&mut self, offset: u64, buf: &mut [u8]) -> bool;
+}
+
+/// A record's identity and sizes, as the scan needs them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Entry {
+    pub(crate) record: u64,
+    pub(crate) parent: u64,
+    pub(crate) name: String,
+    pub(crate) is_directory: bool,
+    pub(crate) sizes: DataSizes,
+    pub(crate) hard_link_count: u16,
+}
+
+/// Reads records from the `$MFT` of a volume.
+pub(crate) struct MftReader<S: VolumeSource> {
+    source: S,
+    geometry: Geometry,
+    /// Where the MFT's own data lives. The MFT is a file and can be fragmented;
+    /// without these runs only its first extent is reachable, and the scan
+    /// would stop early while still reporting a plausible total.
+    runs: Vec<Run>,
+}
+
+impl<S: VolumeSource> MftReader<S> {
+    /// Read the boot sector and the MFT's own run list.
+    ///
+    /// Returns `None` for anything that is not a readable NTFS volume; the
+    /// caller falls back to directory enumeration rather than guessing.
+    pub(crate) fn open(mut source: S) -> Option<Self> {
+        let mut boot = [0u8; 512];
+        if !source.read_at(0, &mut boot) {
+            return None;
+        }
+        let geometry = parse_boot_sector(&boot)?;
+
+        // Chicken-and-egg: the MFT describes itself in record 0, which sits at
+        // the start of the MFT, which the boot sector locates.
+        let mut rec = vec![0u8; geometry.record_size as usize];
+        if !source.read_at(geometry.mft_offset, &mut rec) {
+            return None;
+        }
+        if !apply_fixups(&mut rec, geometry.bytes_per_sector) {
+            return None;
+        }
+        let header = parse_record_header(&rec)?;
+
+        // The MFT's $DATA is non-resident by construction; its run list is what
+        // makes the rest of the records reachable.
+        let mut runs = None;
+        for attr in Attributes::new(&rec, &header) {
+            if attr.type_code == attr_type::DATA && attr.non_resident {
+                let off = run_list_offset(&rec, attr.pos)?;
+                runs = parse_run_list(rec.get(off..)?);
+                break;
+            }
+        }
+        let runs = runs?;
+        if runs.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            source,
+            geometry,
+            runs,
+        })
+    }
+
+    pub(crate) fn geometry(&self) -> Geometry {
+        self.geometry
+    }
+
+    /// Total clusters the MFT occupies, which bounds how many records exist.
+    pub(crate) fn mft_clusters(&self) -> u64 {
+        allocated_clusters(&self.runs)
+    }
+
+    /// How many records the MFT can hold. Reading past this is not an error to
+    /// report, just the end.
+    pub(crate) fn record_count(&self) -> u64 {
+        let bytes = self.mft_clusters() * self.geometry.cluster_size() as u64;
+        bytes / self.geometry.record_size as u64
+    }
+
+    /// Read one record by number, with fixups already applied.
+    ///
+    /// Returns `None` for a record that is out of range, unreadable, or fails
+    /// its torn-write check. A caller iterating records treats all three the
+    /// same way: skip it.
+    pub(crate) fn read_record(&mut self, number: u64) -> Option<Vec<u8>> {
+        let record_size = self.geometry.record_size as u64;
+        let cluster_size = self.geometry.cluster_size() as u64;
+
+        // Records are packed into the MFT's clusters, so a record number maps
+        // to a virtual cluster plus an offset inside it.
+        let byte_offset = number.checked_mul(record_size)?;
+        let vcn = byte_offset / cluster_size;
+        let within = byte_offset % cluster_size;
+        let base = vcn_to_offset(&self.runs, vcn, cluster_size)?;
+
+        let mut buf = vec![0u8; record_size as usize];
+        if !self.source.read_at(base + within, &mut buf) {
+            return None;
+        }
+        if !apply_fixups(&mut buf, self.geometry.bytes_per_sector) {
+            return None;
+        }
+        Some(buf)
+    }
+
+    /// Extract the entry for a record, or `None` when it holds nothing the scan
+    /// cares about (deleted, unnamed, or unreadable).
+    pub(crate) fn entry(&mut self, number: u64) -> Option<Entry> {
+        let rec = self.read_record(number)?;
+        let header = parse_record_header(&rec)?;
+        if !header.in_use {
+            return None;
+        }
+
+        let mut names: Vec<FileName> = Vec::new();
+        let mut sizes: Option<DataSizes> = None;
+        for attr in Attributes::new(&rec, &header) {
+            match attr.type_code {
+                attr_type::FILE_NAME if !attr.non_resident => {
+                    let value = rec.get(attr.value_offset..attr.value_offset + attr.value_length)?;
+                    if let Some(f) = parse_file_name(value) {
+                        names.push(f);
+                    }
+                }
+                // The first $DATA is the file's contents. A later one is a
+                // named alternate stream, which `du` does not count.
+                attr_type::DATA if sizes.is_none() => {
+                    sizes = parse_data_sizes(&rec, &attr);
+                }
+                _ => {}
+            }
+        }
+
+        let links = distinct_links(&names);
+        // Prefer a Win32 name for display; a POSIX-only record still has one.
+        let chosen = links
+            .iter()
+            .find(|f| f.namespace == namespace::WIN32 || f.namespace == namespace::WIN32_AND_DOS)
+            .or_else(|| links.first())?;
+
+        Some(Entry {
+            record: number,
+            parent: chosen.parent,
+            name: chosen.name.clone(),
+            is_directory: header.is_directory,
+            // A record whose $DATA lives in an extension record reports no size
+            // here; $FILE_NAME's copy is the fallback, stale though it can be.
+            sizes: sizes.unwrap_or(DataSizes {
+                real_size: chosen.real_size,
+                allocated_size: chosen.allocated_size,
+            }),
+            hard_link_count: header.hard_link_count,
+        })
+    }
+
+    /// Walk every record, yielding the ones that hold a file or directory.
+    ///
+    /// Records 0..=15 are NTFS's own metadata files (`$MFT`, `$LogFile`,
+    /// `$Bitmap` and friends). They occupy real space, but a user asking where
+    /// their disk went is not asking about those, and `du` on a mounted volume
+    /// cannot see them either -- so they are skipped to keep the two backends
+    /// comparable.
+    pub(crate) fn entries(&mut self) -> Vec<Entry> {
+        const FIRST_USER_RECORD: u64 = 16;
+        let count = self.record_count();
+        let mut out = Vec::new();
+        for n in FIRST_USER_RECORD..count {
+            if let Some(e) = self.entry(n) {
+                out.push(e);
+            }
+        }
+        out
+    }
+}
+
+/// Byte offset of a non-resident attribute's run list within the record.
+///
+/// The offset lives at 0x20 of the attribute header and is relative to the
+/// attribute, not the record.
+fn run_list_offset(rec: &[u8], attr_pos: usize) -> Option<usize> {
+    let rel = u16::from_le_bytes(rec.get(attr_pos + 0x20..attr_pos + 0x22)?.try_into().ok()?);
+    let off = attr_pos.checked_add(rel as usize)?;
+    if off >= rec.len() {
+        return None;
+    }
+    Some(off)
+}
+
+/// Build `record -> path` for a set of entries.
+///
+/// Entries whose parent chain does not reach the root are dropped rather than
+/// attached somewhere plausible: putting an orphan under a guessed parent moves
+/// its bytes into a directory that does not contain it.
+pub(crate) fn paths_for(entries: &[Entry]) -> HashMap<u64, String> {
+    let by_record: HashMap<u64, (String, u64)> = entries
+        .iter()
+        .map(|e| (e.record, (e.name.clone(), e.parent)))
+        .collect();
+
+    entries
+        .iter()
+        .filter_map(|e| {
+            let path = build_path(e.record, |n| by_record.get(&n).cloned())?;
+            Some((e.record, path))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::mft::ROOT_RECORD, *};
+
+    // --- a synthetic NTFS volume ---------------------------------------------
+
+    const SECTOR: usize = 512;
+    const CLUSTER: usize = 4096;
+    const RECORD: usize = 1024;
+    /// Cluster where the MFT starts in the fixtures below.
+    const MFT_LCN: u64 = 4;
+
+    struct MemVolume(Vec<u8>);
+
+    impl VolumeSource for MemVolume {
+        fn read_at(&mut self, offset: u64, buf: &mut [u8]) -> bool {
+            let start = offset as usize;
+            let end = start + buf.len();
+            match self.0.get(start..end) {
+                Some(s) => {
+                    buf.copy_from_slice(s);
+                    true
+                }
+                None => false,
+            }
+        }
+    }
+
+    fn boot_sector() -> Vec<u8> {
+        let mut b = vec![0u8; SECTOR];
+        b[3..11].copy_from_slice(b"NTFS    ");
+        b[11..13].copy_from_slice(&(SECTOR as u16).to_le_bytes());
+        b[13] = (CLUSTER / SECTOR) as u8;
+        b[48..56].copy_from_slice(&MFT_LCN.to_le_bytes());
+        b[64] = -10i8 as u8; // 2^10 = 1024-byte records
+        b
+    }
+
+    /// A record with a valid signature and a fixup array that checks out.
+    fn blank_record(flags: u16, links: u16) -> Vec<u8> {
+        let mut r = vec![0u8; RECORD];
+        r[0..4].copy_from_slice(b"FILE");
+        let usa_off = 48usize;
+        let sectors = RECORD / SECTOR;
+        r[4..6].copy_from_slice(&(usa_off as u16).to_le_bytes());
+        r[6..8].copy_from_slice(&((sectors + 1) as u16).to_le_bytes());
+        let seq = 0x0101u16;
+        r[usa_off..usa_off + 2].copy_from_slice(&seq.to_le_bytes());
+        for i in 0..sectors {
+            // The real bytes are zero here, so the array holds zeroes and each
+            // sector tail holds the sequence number.
+            r[usa_off + 2 + i * 2..usa_off + 4 + i * 2].copy_from_slice(&0u16.to_le_bytes());
+            let tail = (i + 1) * SECTOR - 2;
+            r[tail..tail + 2].copy_from_slice(&seq.to_le_bytes());
+        }
+        r[18..20].copy_from_slice(&links.to_le_bytes());
+        r[20..22].copy_from_slice(&64u16.to_le_bytes()); // first attribute
+        r[22..24].copy_from_slice(&flags.to_le_bytes());
+        r
+    }
+
+    fn set_used(rec: &mut [u8], used: u32) {
+        rec[24..28].copy_from_slice(&used.to_le_bytes());
+    }
+
+    fn push_file_name(rec: &mut [u8], pos: usize, parent: u64, name: &str) -> usize {
+        let units: Vec<u16> = name.encode_utf16().collect();
+        let value_len = 66 + units.len() * 2;
+        let value_off = 24usize;
+        let total = (value_off + value_len).next_multiple_of(8);
+
+        rec[pos..pos + 4].copy_from_slice(&attr_type::FILE_NAME.to_le_bytes());
+        rec[pos + 4..pos + 8].copy_from_slice(&(total as u32).to_le_bytes());
+        rec[pos + 8] = 0; // resident
+        rec[pos + 16..pos + 20].copy_from_slice(&(value_len as u32).to_le_bytes());
+        rec[pos + 20..pos + 22].copy_from_slice(&(value_off as u16).to_le_bytes());
+
+        let v = pos + value_off;
+        rec[v..v + 8].copy_from_slice(&parent.to_le_bytes());
+        rec[v + 64] = units.len() as u8;
+        rec[v + 65] = namespace::WIN32;
+        for (i, u) in units.iter().enumerate() {
+            rec[v + 66 + i * 2..v + 68 + i * 2].copy_from_slice(&u.to_le_bytes());
+        }
+        pos + total
+    }
+
+    fn push_nonresident_data(rec: &mut [u8], pos: usize, alloc: u64, real: u64) -> usize {
+        let total = 72usize;
+        rec[pos..pos + 4].copy_from_slice(&attr_type::DATA.to_le_bytes());
+        rec[pos + 4..pos + 8].copy_from_slice(&(total as u32).to_le_bytes());
+        rec[pos + 8] = 1; // non-resident
+        rec[pos + 0x28..pos + 0x30].copy_from_slice(&alloc.to_le_bytes());
+        rec[pos + 0x30..pos + 0x38].copy_from_slice(&real.to_le_bytes());
+        pos + total
+    }
+
+    /// `$MFT`'s own record: a non-resident `$DATA` whose run list covers
+    /// `clusters` clusters starting at `MFT_LCN`.
+    fn mft_record(clusters: u64) -> Vec<u8> {
+        let mut r = blank_record(0x0001, 1);
+        let pos = 64usize;
+        let total = 72usize;
+        r[pos..pos + 4].copy_from_slice(&attr_type::DATA.to_le_bytes());
+        r[pos + 4..pos + 8].copy_from_slice(&(total as u32).to_le_bytes());
+        r[pos + 8] = 1; // non-resident
+        let run_off = 0x40u16; // within the attribute
+        r[pos + 0x20..pos + 0x22].copy_from_slice(&run_off.to_le_bytes());
+        // 0x11: one length byte, one offset byte.
+        let ro = pos + run_off as usize;
+        r[ro] = 0x11;
+        r[ro + 1] = clusters as u8;
+        r[ro + 2] = MFT_LCN as u8;
+        r[ro + 3] = 0x00; // end of list
+        set_used(&mut r, (pos + total) as u32);
+        r
+    }
+
+    /// Volume holding `records` starting at record 0, laid out as the MFT.
+    fn volume(records: Vec<Vec<u8>>) -> MemVolume {
+        let mft_byte_offset = MFT_LCN as usize * CLUSTER;
+        let mut v = boot_sector();
+        v.resize(mft_byte_offset, 0);
+        for r in &records {
+            v.extend_from_slice(r);
+        }
+        // Round out to whole clusters so the run list's length is honest.
+        let records_per_cluster = CLUSTER / RECORD;
+        let clusters = records.len().div_ceil(records_per_cluster).max(1);
+        v.resize(mft_byte_offset + clusters * CLUSTER, 0);
+        MemVolume(v)
+    }
+
+    /// Records 0..16 are NTFS metadata; the fixtures fill them with blanks so
+    /// user records land at realistic numbers.
+    fn with_metadata_records(mut user: Vec<Vec<u8>>, mft_clusters: u64) -> Vec<Vec<u8>> {
+        let mut records = vec![mft_record(mft_clusters)];
+        while records.len() < 16 {
+            records.push(blank_record(0x0000, 0)); // not in use
+        }
+        records.append(&mut user);
+        records
+    }
+
+    fn file_record(parent: u64, name: &str, alloc: u64, real: u64, links: u16) -> Vec<u8> {
+        let mut r = blank_record(0x0001, links);
+        let mut p = 64usize;
+        p = push_file_name(&mut r, p, parent, name);
+        p = push_nonresident_data(&mut r, p, alloc, real);
+        set_used(&mut r, p as u32);
+        r
+    }
+
+    fn dir_record(parent: u64, name: &str) -> Vec<u8> {
+        let mut r = blank_record(0x0003, 1); // in use + directory
+        let mut p = 64usize;
+        p = push_file_name(&mut r, p, parent, name);
+        set_used(&mut r, p as u32);
+        r
+    }
+
+    // --- tests ---------------------------------------------------------------
+
+    #[test]
+    fn opens_a_volume_and_finds_the_mft_run_list() {
+        let vol = volume(with_metadata_records(vec![], 8));
+        let reader = MftReader::open(vol).expect("should open");
+        assert_eq!(reader.geometry().record_size, RECORD as u32);
+        assert_eq!(reader.geometry().cluster_size(), CLUSTER as u32);
+        assert_eq!(reader.mft_clusters(), 8, "from $MFT's own run list");
+        assert_eq!(reader.record_count(), 8 * CLUSTER as u64 / RECORD as u64);
+    }
+
+    #[test]
+    fn refuses_a_volume_that_is_not_ntfs() {
+        let mut v = volume(with_metadata_records(vec![], 8));
+        v.0[3..11].copy_from_slice(b"FAT32   ");
+        assert!(MftReader::open(v).is_none());
+    }
+
+    #[test]
+    fn refuses_a_volume_too_short_to_hold_a_boot_sector() {
+        assert!(MftReader::open(MemVolume(vec![0u8; 16])).is_none());
+    }
+
+    #[test]
+    fn refuses_a_volume_whose_mft_record_is_unreadable() {
+        // The boot sector points past the end of the volume.
+        let mut v = volume(with_metadata_records(vec![], 8));
+        v.0.truncate(SECTOR);
+        assert!(MftReader::open(v).is_none());
+    }
+
+    #[test]
+    fn reads_a_file_record_end_to_end() {
+        let records =
+            with_metadata_records(vec![file_record(ROOT_RECORD, "notes.txt", 8192, 5000, 1)], 8);
+        let mut reader = MftReader::open(volume(records)).expect("open");
+        let e = reader.entry(16).expect("record 16 is the file");
+        assert_eq!(e.name, "notes.txt");
+        assert_eq!(e.parent, ROOT_RECORD);
+        assert!(!e.is_directory);
+        assert_eq!(e.sizes.real_size, 5000);
+        assert_eq!(e.sizes.allocated_size, 8192);
+    }
+
+    #[test]
+    fn a_directory_record_is_marked_as_one() {
+        let records = with_metadata_records(vec![dir_record(ROOT_RECORD, "Users")], 8);
+        let mut reader = MftReader::open(volume(records)).expect("open");
+        assert!(reader.entry(16).expect("entry").is_directory);
+    }
+
+    #[test]
+    fn a_deleted_record_yields_nothing() {
+        let mut rec = file_record(ROOT_RECORD, "gone.txt", 4096, 100, 1);
+        rec[22..24].copy_from_slice(&0u16.to_le_bytes()); // not in use
+        let records = with_metadata_records(vec![rec], 8);
+        let mut reader = MftReader::open(volume(records)).expect("open");
+        assert!(reader.entry(16).is_none());
+    }
+
+    #[test]
+    fn iterating_skips_the_ntfs_metadata_records() {
+        let records = with_metadata_records(
+            vec![
+                dir_record(ROOT_RECORD, "Users"),
+                file_record(16, "a.txt", 4096, 10, 1),
+            ],
+            8,
+        );
+        let mut reader = MftReader::open(volume(records)).expect("open");
+        let entries = reader.entries();
+        assert_eq!(
+            entries.len(),
+            2,
+            "$MFT and friends must not appear as user files"
+        );
+        assert_eq!(entries[0].name, "Users");
+        assert_eq!(entries[1].name, "a.txt");
+    }
+
+    #[test]
+    fn a_record_past_the_end_of_the_mft_is_not_readable() {
+        let records = with_metadata_records(vec![], 8);
+        let mut reader = MftReader::open(volume(records)).expect("open");
+        let past = reader.record_count() + 10;
+        assert!(reader.read_record(past).is_none());
+    }
+
+    #[test]
+    fn builds_paths_from_parent_references() {
+        // 16 = Users (under root), 17 = alice (under Users), 18 = notes.txt
+        let records = with_metadata_records(
+            vec![
+                dir_record(ROOT_RECORD, "Users"),
+                dir_record(16, "alice"),
+                file_record(17, "notes.txt", 4096, 10, 1),
+            ],
+            8,
+        );
+        let mut reader = MftReader::open(volume(records)).expect("open");
+        let entries = reader.entries();
+        let paths = paths_for(&entries);
+        assert_eq!(
+            paths.get(&18).map(String::as_str),
+            Some("Users\\alice\\notes.txt")
+        );
+        assert_eq!(paths.get(&16).map(String::as_str), Some("Users"));
+    }
+
+    #[test]
+    fn an_orphaned_record_gets_no_path() {
+        // Parent 999 does not exist, so the chain never reaches the root.
+        let records = with_metadata_records(vec![file_record(999, "orphan.txt", 4096, 10, 1)], 8);
+        let mut reader = MftReader::open(volume(records)).expect("open");
+        let paths = paths_for(&reader.entries());
+        assert!(
+            paths.is_empty(),
+            "attaching it to a guessed parent would move its bytes"
+        );
+    }
+
+    #[test]
+    fn a_torn_record_is_skipped_rather_than_misread() {
+        let mut rec = file_record(ROOT_RECORD, "torn.txt", 4096, 10, 1);
+        // Break the second sector's fixup so the torn-write check fails.
+        rec[2 * SECTOR - 2..2 * SECTOR].copy_from_slice(&0xDEADu16.to_le_bytes());
+        let records = with_metadata_records(vec![rec], 8);
+        let mut reader = MftReader::open(volume(records)).expect("open");
+        assert!(reader.entry(16).is_none());
+    }
+
+    #[test]
+    fn the_hard_link_count_is_carried_through() {
+        let records =
+            with_metadata_records(vec![file_record(ROOT_RECORD, "linked.txt", 4096, 10, 3)], 8);
+        let mut reader = MftReader::open(volume(records)).expect("open");
+        assert_eq!(
+            reader.entry(16).expect("entry").hard_link_count,
+            3,
+            "dedupe needs this, and it is free here"
+        );
+    }
+
+    #[test]
+    fn a_fragmented_mft_reaches_records_in_its_second_extent() {
+        // Two runs: cluster 4 (1 cluster) then cluster 9 (1 cluster). Records
+        // 0..3 live in the first, 4..7 in the second.
+        let mut mft = blank_record(0x0001, 1);
+        let pos = 64usize;
+        mft[pos..pos + 4].copy_from_slice(&attr_type::DATA.to_le_bytes());
+        mft[pos + 4..pos + 8].copy_from_slice(&72u32.to_le_bytes());
+        mft[pos + 8] = 1;
+        mft[pos + 0x20..pos + 0x22].copy_from_slice(&0x40u16.to_le_bytes());
+        let ro = pos + 0x40;
+        mft[ro] = 0x11; // run 1: len 1, lcn +4
+        mft[ro + 1] = 1;
+        mft[ro + 2] = 4;
+        mft[ro + 3] = 0x11; // run 2: len 1, lcn +5 (absolute 9)
+        mft[ro + 4] = 1;
+        mft[ro + 5] = 5;
+        mft[ro + 6] = 0x00;
+        set_used(&mut mft, (pos + 72) as u32);
+
+        // Lay the volume out by hand: first extent at cluster 4, second at 9.
+        let mut v = boot_sector();
+        v.resize(4 * CLUSTER, 0);
+        v.extend_from_slice(&mft); // record 0
+        for _ in 1..4 {
+            v.extend_from_slice(&blank_record(0x0000, 0));
+        }
+        v.resize(9 * CLUSTER, 0);
+        // Records 4..8 land in the second extent; put a file at record 4.
+        v.extend_from_slice(&file_record(ROOT_RECORD, "far.txt", 8192, 1234, 1));
+        for _ in 5..8 {
+            v.extend_from_slice(&blank_record(0x0000, 0));
+        }
+
+        let mut reader = MftReader::open(MemVolume(v)).expect("open");
+        assert_eq!(reader.record_count(), 8, "two clusters of records");
+        let e = reader.entry(4).expect("record 4 is in the second extent");
+        assert_eq!(
+            e.name, "far.txt",
+            "without the run list this record is unreachable, and the scan \
+             would stop early while still looking complete"
+        );
+        assert_eq!(e.sizes.real_size, 1234);
+    }
+}

--- a/hyperdu-core/src/platform/windows_impl/mft_reader.rs
+++ b/hyperdu-core/src/platform/windows_impl/mft_reader.rs
@@ -211,6 +211,74 @@ impl<S: VolumeSource> MftReader<S> {
     }
 }
 
+// --- turning records into a StatMap ------------------------------------------
+
+/// Fold MFT entries into the per-directory map the rest of the scan expects.
+///
+/// `root_prefix` is prepended to every path (`C:\` for a whole-volume scan), so
+/// the result is addressed the same way the enumeration backend addresses it.
+/// Without that the two backends' maps cannot be compared, and comparing them
+/// is how this backend gets shown to be correct.
+///
+/// Hardlink handling matches GNU `du`: a file with several links is charged
+/// once, to whichever link is met first. `count_hardlinks` turns that off, as
+/// it does elsewhere.
+pub(crate) fn to_stat_map(
+    entries: &[Entry],
+    paths: &HashMap<u64, String>,
+    root_prefix: &str,
+    count_hardlinks: bool,
+    compute_physical: bool,
+) -> crate::StatMap {
+    let mut map: crate::StatMap = crate::StatMap::default();
+    let mut counted_links: std::collections::HashSet<u64> = std::collections::HashSet::new();
+
+    // Directories come first so an empty one still appears in the map. The
+    // enumeration backend lists it, and a directory that exists in one map but
+    // not the other shows up as a spurious difference.
+    for e in entries.iter().filter(|e| e.is_directory) {
+        if let Some(p) = paths.get(&e.record) {
+            map.entry(join_path(root_prefix, p)).or_default();
+        }
+    }
+
+    for e in entries.iter().filter(|e| !e.is_directory) {
+        // A file's bytes belong to the directory holding it, not to itself.
+        let Some(parent_path) = paths.get(&e.parent) else {
+            // Parent outside the scanned set: dropping the file is the same
+            // choice `paths_for` makes for orphans, and for the same reason.
+            continue;
+        };
+        if !count_hardlinks && e.hard_link_count > 1 && !counted_links.insert(e.record) {
+            continue;
+        }
+
+        let stat = map.entry(join_path(root_prefix, parent_path)).or_default();
+        stat.files += 1;
+        stat.logical += e.sizes.real_size;
+        stat.physical += if compute_physical {
+            e.sizes.allocated_size
+        } else {
+            e.sizes.real_size
+        };
+    }
+
+    map
+}
+
+fn join_path(prefix: &str, rest: &str) -> std::path::PathBuf {
+    if rest.is_empty() {
+        return std::path::PathBuf::from(prefix);
+    }
+    let mut s = String::with_capacity(prefix.len() + 1 + rest.len());
+    s.push_str(prefix);
+    if !prefix.ends_with('\\') && !prefix.ends_with('/') {
+        s.push('\\');
+    }
+    s.push_str(rest);
+    std::path::PathBuf::from(s)
+}
+
 // --- the real volume ---------------------------------------------------------
 
 /// A volume opened for reading, as `\\.\C:`.
@@ -716,6 +784,124 @@ mod tests {
             reader.entry(16).expect("entry").hard_link_count,
             3,
             "dedupe needs this, and it is free here"
+        );
+    }
+
+    // --- StatMap conversion --------------------------------------------------
+
+    fn entry(record: u64, parent: u64, name: &str, is_dir: bool, real: u64, alloc: u64) -> Entry {
+        Entry {
+            record,
+            parent,
+            name: name.to_string(),
+            is_directory: is_dir,
+            sizes: DataSizes {
+                real_size: real,
+                allocated_size: alloc,
+            },
+            hard_link_count: 1,
+        }
+    }
+
+    fn paths(pairs: &[(u64, &str)]) -> HashMap<u64, String> {
+        pairs.iter().map(|(r, p)| (*r, p.to_string())).collect()
+    }
+
+    #[test]
+    fn a_files_bytes_land_in_its_parent_directory() {
+        let entries = vec![
+            entry(16, ROOT_RECORD, "Users", true, 0, 0),
+            entry(17, 16, "a.txt", false, 1000, 4096),
+        ];
+        let p = paths(&[(16, "Users")]);
+        let map = to_stat_map(&entries, &p, r"C:\", false, true);
+        let users = map
+            .get(std::path::Path::new(r"C:\Users"))
+            .expect("Users is in the map");
+        assert_eq!(users.files, 1);
+        assert_eq!(users.logical, 1000);
+        assert_eq!(users.physical, 4096, "allocated, not apparent");
+    }
+
+    #[test]
+    fn an_empty_directory_still_appears() {
+        let entries = vec![entry(16, ROOT_RECORD, "Empty", true, 0, 0)];
+        let p = paths(&[(16, "Empty")]);
+        let map = to_stat_map(&entries, &p, r"C:\", false, true);
+        assert!(
+            map.contains_key(std::path::Path::new(r"C:\Empty")),
+            "the enumeration backend lists it, so this one must too"
+        );
+    }
+
+    #[test]
+    fn logical_only_charges_the_apparent_size() {
+        let entries = vec![
+            entry(16, ROOT_RECORD, "d", true, 0, 0),
+            entry(17, 16, "sparse.img", false, 1_000_000, 4096),
+        ];
+        let p = paths(&[(16, "d")]);
+        let map = to_stat_map(&entries, &p, r"C:\", false, false);
+        let d = map.get(std::path::Path::new(r"C:\d")).expect("d");
+        assert_eq!(
+            d.physical, 1_000_000,
+            "compute_physical=false means logical"
+        );
+    }
+
+    #[test]
+    fn a_hardlinked_file_is_charged_once() {
+        let mut a = entry(17, 16, "link-a.txt", false, 1000, 4096);
+        a.hard_link_count = 2;
+        let entries = vec![entry(16, ROOT_RECORD, "d", true, 0, 0), a.clone(), a];
+        let p = paths(&[(16, "d")]);
+        let map = to_stat_map(&entries, &p, r"C:\", false, true);
+        assert_eq!(
+            map.get(std::path::Path::new(r"C:\d")).expect("d").files,
+            1,
+            "GNU du charges a hardlinked file to the first link only"
+        );
+    }
+
+    #[test]
+    fn count_hardlinks_charges_every_link() {
+        let mut a = entry(17, 16, "link-a.txt", false, 1000, 4096);
+        a.hard_link_count = 2;
+        let entries = vec![entry(16, ROOT_RECORD, "d", true, 0, 0), a.clone(), a];
+        let p = paths(&[(16, "d")]);
+        let map = to_stat_map(&entries, &p, r"C:\", true, true);
+        assert_eq!(map.get(std::path::Path::new(r"C:\d")).expect("d").files, 2);
+    }
+
+    #[test]
+    fn a_file_whose_parent_is_unknown_is_dropped() {
+        // Same choice `paths_for` makes for orphans, for the same reason.
+        let entries = vec![entry(17, 999, "orphan.txt", false, 1000, 4096)];
+        let map = to_stat_map(&entries, &paths(&[]), r"C:\", false, true);
+        assert!(map.is_empty());
+    }
+
+    #[test]
+    fn a_file_directly_under_the_root_lands_at_the_root() {
+        let entries = vec![entry(16, ROOT_RECORD, "top.txt", false, 500, 4096)];
+        // The root's own path is the empty string.
+        let p = paths(&[(ROOT_RECORD, "")]);
+        let map = to_stat_map(&entries, &p, r"C:\", false, true);
+        assert_eq!(
+            map.get(std::path::Path::new(r"C:\")).expect("root").files,
+            1
+        );
+    }
+
+    #[test]
+    fn the_prefix_is_not_doubled_when_it_already_ends_in_a_separator() {
+        assert_eq!(
+            join_path(r"C:\", "Users"),
+            std::path::PathBuf::from(r"C:\Users")
+        );
+        assert_eq!(
+            join_path(r"C:", "Users"),
+            std::path::PathBuf::from(r"C:\Users")
         );
     }
 

--- a/hyperdu-core/src/platform/windows_impl/mod.rs
+++ b/hyperdu-core/src/platform/windows_impl/mod.rs
@@ -12,6 +12,11 @@
 //! Set `HYPERDU_WIN_USE_NTQUERY=0` to force the Win32 path.
 
 mod entry;
+/// NTFS on-disk parsing for the `$MFT` backend (#15). Pure parsing, and not yet
+/// wired into `process_dir`: reading a volume needs administrator rights, so
+/// the parser is landed and unit-tested first.
+#[cfg(target_env = "msvc")]
+mod mft;
 #[cfg(target_env = "msvc")]
 mod nt;
 mod path;

--- a/hyperdu-core/src/platform/windows_impl/mod.rs
+++ b/hyperdu-core/src/platform/windows_impl/mod.rs
@@ -17,6 +17,11 @@ mod entry;
 /// the parser is landed and unit-tested first.
 #[cfg(target_env = "msvc")]
 mod mft;
+/// Reading MFT records off a volume, on top of `mft`. The volume is behind a
+/// trait so the whole path is testable against a synthetic volume without the
+/// administrator rights a real one needs.
+#[cfg(target_env = "msvc")]
+mod mft_reader;
 #[cfg(target_env = "msvc")]
 mod nt;
 mod path;

--- a/hyperdu-core/src/platform/windows_impl/mod.rs
+++ b/hyperdu-core/src/platform/windows_impl/mod.rs
@@ -52,6 +52,81 @@ pub fn process_dir(ctx: &ScanContext, dctx: &DirContext, map: &mut StatMap) {
     win32::process_dir(ctx, dctx, map)
 }
 
+/// Scan a whole volume by reading its `$MFT`. See
+/// [`crate::platform::scan_volume_via_mft`].
+///
+/// Every `None` here is a reason to use the enumeration backend instead, and
+/// none of them is an error worth reporting: not asked for, not elevated, not a
+/// volume root, not NTFS, or the parse did not hold together.
+#[cfg(target_env = "msvc")]
+pub fn scan_volume_via_mft(root: &std::path::Path, opt: &crate::Options) -> Option<crate::StatMap> {
+    if !opt.use_mft {
+        return None;
+    }
+    // The MFT covers a whole volume. Scanning a subdirectory this way would
+    // mean reading every record and discarding most of them, which is slower
+    // than walking the subdirectory -- and the point of this backend is that it
+    // does not walk.
+    let drive = volume_root_letter(root)?;
+    if !mft_reader::is_elevated() {
+        return None;
+    }
+
+    let mut volume = mft_reader::WindowsVolume::open(drive)?;
+    // Narrow the read alignment now that the geometry is known, so records stop
+    // pulling in more sectors than they need.
+    let mut reader = mft_reader::MftReader::open(&mut volume)?;
+    let geometry = reader.geometry();
+    let entries = reader.entries();
+    drop(reader);
+    volume.set_sector_size(geometry.bytes_per_sector);
+
+    let paths = mft_reader::paths_for(&entries);
+    let prefix = format!("{}:\\", drive.to_ascii_uppercase());
+    Some(mft_reader::to_stat_map(
+        &entries,
+        &paths,
+        &prefix,
+        opt.count_hardlinks,
+        opt.compute_physical,
+    ))
+}
+
+#[cfg(not(target_env = "msvc"))]
+pub fn scan_volume_via_mft(
+    _root: &std::path::Path,
+    _opt: &crate::Options,
+) -> Option<crate::StatMap> {
+    None
+}
+
+/// Drive letter when `root` is the root of a volume (`C:\`), else `None`.
+///
+/// A subdirectory returns `None` on purpose: see `scan_volume_via_mft`.
+#[cfg(target_env = "msvc")]
+fn volume_root_letter(root: &std::path::Path) -> Option<char> {
+    use std::path::{Component, Prefix};
+
+    let mut components = root.components();
+    let letter = match components.next()? {
+        Component::Prefix(p) => match p.kind() {
+            Prefix::Disk(d) | Prefix::VerbatimDisk(d) => d as char,
+            // UNC shares and device paths have no MFT we can open this way.
+            _ => return None,
+        },
+        _ => return None,
+    };
+    // After the prefix there must be a root and nothing else.
+    match components.next() {
+        Some(Component::RootDir) => {}
+        _ => return None,
+    }
+    if components.next().is_some() {
+        return None;
+    }
+    Some(letter)
+}
+
 /// Prefix identifying the volume of `dir` (`C:`, `\\?\C:`, `\\server\share`).
 /// Relative paths have none and are simply never cached.
 #[cfg(target_env = "msvc")]


### PR DESCRIPTION
Issue #15 の実装。**残るのは既存バックエンドとの一致検証だけ**という状態まで持っていきました。

## 中心的な工夫: ボリュームを trait の裏に置く

実際の `\\.\C:` は管理者権限を要するため、それを開くテストは**昇格した環境でしか動かず、他では常にスキップされます**。

`VolumeSource` trait で抽象化したことで、テストは**合成 NTFS ボリュームをメモリ上に組み立て**、以下を権限なしで通します。

```
ブートセクタ → $MFT の実行リスト → レコード走査 → 名前とサイズの抽出 → パス構築 → StatMap
```

**単体テスト 107 件、全通過**（clippy 警告 0 件）。

## 構成

| ファイル | 役割 | 行数 |
|---|---|---|
| `mft.rs` | NTFS 構造の解析（純粋関数） | 1,314 |
| `mft_reader.rs` | 読み出し、走査、`StatMap` 変換、Windows ボリューム実装 | 約 800 |

## 実装したもの

### 1. 解析（`mft.rs`、テスト 61 件）

ブートセクタ、fixup と破れた書き込みの検出、レコードヘッダ、属性チェーン、`$FILE_NAME`、`$DATA`、**実行リスト**、**`$ATTRIBUTE_LIST`**、**パス再構築**、**ハードリンク判定**。

### 2. 読み出し（`MftReader`、テスト 14 件）

- **`open` は鶏と卵の問題を解きます。** `$MFT` は自身をレコード 0 で記述し、そのレコードは MFT の先頭にあり、MFT の位置はブートセクタが持ちます
- **`read_record` は連続配置を仮定しません。** レコード番号を仮想クラスタ + オフセットへ写し、実行リストで物理位置へ変換します
- **`entries` はレコード 0〜15 を飛ばします。** NTFS 自身のメタデータで、`du` からも見えません。**既存バックエンドと数値を比較可能に保つため**です

### 3. `StatMap` 変換（`to_stat_map`、テスト 8 件）

- ファイルのバイトは**格納しているディレクトリに計上**します（`du` と同じ）
- **空のディレクトリもマップに載せます。** 列挙バックエンドは載せるので、片方にしか存在しないと差分として現れます
- **ハードリンクは最初に出会ったリンクにだけ計上**します（`count_hardlinks` で全リンクに変更可）
- `root_prefix` を全パスに付けるのは、**列挙バックエンドと同じ番地で結果を持ち、突き合わせられるようにするため**です

### 4. Windows ボリューム実装（`WindowsVolume`、テスト 2 件）

- `\\.\C:` を **`GENERIC_READ` のみ**で開きます。**書き込みは行いません**
- **セクタ整列を吸収します。** ボリュームハンドルはセクタ境界・整数倍長でしか読めませんが、MFT レコードはどちらも満たしません。要求範囲を内包するセクタ群へ広げて読み、必要なバイトだけ切り出します。**これは実ボリュームでしか現れず、合成ボリュームのテストでは踏まない部分**なので明示的に扱いました
- **`is_elevated` で事前に判定**します。走査の奥から「アクセス拒否」を返すより「管理者権限が要る」と言えるほうが行動可能だからです

## 正しさに関わる判断

いずれも間違えると**もっともらしいが誤った数値**が出ます。

| 判断 | 誤ると何が起きるか |
|---|---|
| **実行リストを辿る** | 断片化した MFT で**走査が黙って打ち切られ、総量はもっともらしく見える** |
| LCN オフセットは符号付き | 遠く離れた位置を指す |
| 疎な実行は割り当てゼロ | 全スパースファイルが過大計上 |
| 不正な実行リストは `None` | 部分的な結果が完全な答えのふりをして過少報告 |
| **`$ATTRIBUTE_LIST` を追う** | **まさに最大のファイルの `$DATA` を取りこぼす** |
| 孤立レコードにパスを与えない | バイトが実際には含まれないディレクトリへ移動 |
| **8.3 別名を数えない** | **短い名前を持つファイルが二重計上**（システムボリュームでは大半） |
| `$DATA` は最初のものだけ | 代替ストリームを二重計上 |
| 常駐 `$DATA` はクラスタを占有しない | 全小ファイルを過大計上 |

## この環境で確認できたこと

**非昇格環境であること自体が検証になりました。** `opening_a_volume_agrees_with_the_elevation_check` が通ったことは、`WindowsVolume::open` が正しく `None` を返し、**フォールバック経路が機能している**ことを意味します。

## まだ接続していません

`process_dir` の振り分けは従来どおり `nt` → `win32` のままで、**実行時の挙動は一切変わりません**。

**MFT バックエンドはディレクトリ単位ではなくボリューム全体を一度に読むため、統合点は `process_dir` ではなく `scan_directory` の側になります。** これは既存の 2 バックエンドと構造が違う点で、接続時に設計判断が要ります。

## 残るもの

1. `scan_directory` レベルでの統合と `--mft` オプション
2. **既存バックエンドとの合計値の一致検証**（Issue #15 が求めるフィクスチャ: ハードリンク、圧縮、スパース、再解析ポイント）— **要昇格**

**2 がこのバックエンドの正しさを決める検証**です。`whoami /groups` の整合性レベルが `Medium Mandatory Level`（非昇格）のため、この環境では実行できません。

## 作業中に見つかった項目

- `windows_impl/mod.rs` の既存フォールバック機構（`rejected` モジュール）は**ディレクトリ単位**の振り分けなので、**ボリューム全体を読む MFT バックエンドには流用できません**。統合は別の層になります
- 再解析ポイントは**未着手**です。OneDrive のプレースホルダは論理サイズを持ちながらローカルの割り当てがゼロなので、`$DATA` の割り当てサイズをそのまま使えば正しく 0 と数えられるはずですが、**未検証です**
- **`mft.rs` が 1,314 行と目安（800 行）を超えています。** 解析の対象別にさらに分割する余地があります

---

**環境**: Windows 11 / NTFS、`RUSTUP_TOOLCHAIN=1.98.0`。合成ボリュームのテストはプラットフォーム非依存ですが、モジュールは `#[cfg(target_env = "msvc")]` の下にあります。
