### PR TITLE
fix: --mft の StatMap もロールアップする。9 倍の差は単位の取り違えだった（#37）

### DIFF
--- a/hyperdu-core/src/lib.rs
+++ b/hyperdu-core/src/lib.rs
@@ -565,7 +565,13 @@ pub fn scan_directory(root: impl AsRef<Path>, opt: &Options) -> Result<StatMap> 
     // and the normal scan runs: a slower correct answer beats a fast partial
     // one. Off unless `use_mft` is set.
     if let Some(map) = platform::scan_volume_via_mft(root, opt) {
-        return Ok(map);
+        // Roll up here too. `to_stat_map` charges each file to its own
+        // directory, which is what the walking backends produce *before*
+        // `scan_directory_with` rolls them up -- returning it as-is handed
+        // callers a map with different semantics depending on which backend
+        // ran, so a directory's reported size was its own bytes under `--mft`
+        // and its whole subtree's everywhere else.
+        return Ok(rollup::rollup_child_to_parent(map));
     }
     let scanner = Arc::new(crate::scanner::platform_scanner());
     scan_directory_with(root, opt, scanner)

--- a/hyperdu-core/src/platform/windows_impl/mft_reader.rs
+++ b/hyperdu-core/src/platform/windows_impl/mft_reader.rs
@@ -304,6 +304,13 @@ pub(crate) fn to_stat_map(
     let mut map: crate::StatMap = crate::StatMap::default();
     let mut counted_links: std::collections::HashSet<u64> = std::collections::HashSet::new();
 
+    // The volume root, which no record supplies: `entries` starts at the first
+    // user record and the root is record 5, below it. The walking backends
+    // insert each directory before reading it, so their root is always present;
+    // without this the rolled-up totals have nowhere to accumulate and the
+    // whole-volume figure reads as zero.
+    map.entry(join_path(root_prefix, "")).or_default();
+
     // Directories come first so an empty one still appears in the map. The
     // enumeration backend lists it, and a directory that exists in one map but
     // not the other shows up as a spurious difference.
@@ -990,7 +997,32 @@ mod tests {
         // Same choice `paths_for` makes for orphans, for the same reason.
         let entries = vec![entry(17, 999, "orphan.txt", false, 1000, 4096)];
         let map = to_stat_map(&entries, &paths(&[]), r"C:\", false, true);
-        assert!(map.is_empty());
+        let root = map.get(std::path::Path::new(r"C:\")).expect("root");
+        assert_eq!(root.files, 0, "the orphan is dropped");
+        assert_eq!(map.len(), 1, "only the root remains");
+    }
+
+    // No record supplies the volume root: `entries` starts at the first user
+    // record and the root is record 5. Without an explicit entry the rolled-up
+    // totals have nowhere to accumulate and the whole-volume figure reads as
+    // zero -- which is exactly what a real volume did. See #37.
+    #[test]
+    fn the_volume_root_is_always_in_the_map() {
+        let empty = to_stat_map(&[], &paths(&[]), r"C:\", false, true);
+        assert!(
+            empty.contains_key(std::path::Path::new(r"C:\")),
+            "even an empty volume must have a root entry to roll up into"
+        );
+
+        // And with real entries whose paths never mention the root.
+        let entries = vec![
+            entry(16, ROOT_RECORD, "Windows", true, 0, 0),
+            entry(17, 16, "notepad.exe", false, 1000, 4096),
+        ];
+        let p = paths(&[(16, "Windows"), (17, r"Windows\notepad.exe")]);
+        let map = to_stat_map(&entries, &p, r"C:\", false, true);
+        assert!(map.contains_key(std::path::Path::new(r"C:\")));
+        assert!(map.contains_key(std::path::Path::new(r"C:\Windows")));
     }
 
     #[test]

--- a/hyperdu-core/tests/mft_parity.rs
+++ b/hyperdu-core/tests/mft_parity.rs
@@ -31,32 +31,37 @@ fn parity_root() -> PathBuf {
         .unwrap_or_else(|_| PathBuf::from(r"C:\"))
 }
 
-fn totals(map: &hyperdu_core::StatMap) -> (u64, u64, u64) {
-    map.values().fold((0, 0, 0), |(l, p, f), s| {
-        (l + s.logical, p + s.physical, f + s.files)
-    })
+/// The scan's totals, read from the root entry.
+///
+/// NOT `map.values().sum()`. `scan_directory` rolls totals up, so every
+/// directory holds its whole subtree and summing counts each file once per
+/// ancestor -- which is exactly the mistake this test made when it first ran,
+/// producing a 9x "discrepancy" that was entirely the summing. Every other
+/// test in this crate reads the root entry; so does this one now.
+fn totals(map: &hyperdu_core::StatMap, root: &std::path::Path) -> (u64, u64, u64) {
+    map.get(root)
+        .map(|s| (s.logical, s.physical, s.files))
+        .unwrap_or((0, 0, 0))
 }
 
-/// This found a real bug, and not the one it was looking for.
+/// This found two real bugs, and neither was the one it first appeared to.
 ///
 /// On a GitHub Actions Windows runner -- which is elevated, so it actually ran
-/// -- the two backends disagreed by 9x on file counts while agreeing on
-/// directories to within 0.1%. The obvious reading was that the MFT side was
-/// missing records, and the first fix was aimed there. It changed nothing.
+/// -- the backends read 9x apart on files while agreeing on directories to
+/// within 0.1%. Two rounds of chasing that as an MFT under-count changed
+/// nothing, because neither backend was miscounting:
 ///
-/// `fsutil fsinfo ntfsinfo` settled it: Windows reports the MFT as 1.29 GB,
-/// exactly what this backend computes from the run list. At 1 KB per record
-/// that is ~1.35M records, and a volume cannot hold more files than it has
-/// records -- so enumeration's 10.2M is the impossible number, not the MFT's
-/// 1.13M.
+///   1. This test summed `map.values()`. `scan_directory` rolls totals up, so
+///      every directory holds its subtree and the sum counts each file once per
+///      ancestor. The 9x was the average tree depth. Fixed by reading the root
+///      entry, as every other test in this crate already did.
+///   2. `scan_directory` returned the MFT map without rolling it up, so the two
+///      backends really did produce different-meaning maps -- just not in a way
+///      that made either one's counts wrong. Fixed in lib.rs.
 ///
-/// Tracked as #37. Until that is resolved this test fails on a real volume,
-/// and it should: the two backends genuinely disagree.
-///
-/// It is still ignored rather than failing CI, because the bug it now points
-/// at is in the enumeration path and unrelated to whatever else is being
-/// changed. Run it with `--ignored --nocapture`.
-#[ignore = "backends disagree; the enumeration side over-counts, see #37"]
+/// The lesson worth keeping: a 9x gap that looks like a counting bug can be a
+/// units bug. `fsutil fsinfo ntfsinfo` is the tiebreaker -- an MFT of N bytes
+/// holds N/1024 records, and a volume cannot have more files than records.
 #[test]
 fn the_mft_backend_agrees_with_directory_enumeration() {
     let root = parity_root();
@@ -94,8 +99,8 @@ fn the_mft_backend_agrees_with_directory_enumeration() {
     let from_mft = scan_directory(&root, &mft_opt).expect("mft scan");
     unsafe { std::env::remove_var("HYPERDU_MFT_DIAG") };
 
-    let (wl, wp, wf) = totals(&walked);
-    let (ml, mp, mf) = totals(&from_mft);
+    let (wl, wp, wf) = totals(&walked, &root);
+    let (ml, mp, mf) = totals(&from_mft, &root);
 
     eprintln!("root:        {}", root.display());
     eprintln!(


### PR DESCRIPTION
#37 の 9 倍の差は、**どちらのバックエンドの計数バグでもありませんでした**。原因は 2 つあり、どちらも「何を比べていたか」の問題でした。

## 1. テストが `map.values()` を合計していた（私の誤り）

`scan_directory` はロールアップして返すので、**各ディレクトリは部分木の合計を持ちます**。全部足すと 1 ファイルが祖先の数だけ数えられます。**9 倍は平均の木の深さでした。**

`rollup.rs` の単体テスト自身がこれを示しています。

```rust
// 実ファイル数 = 1 + 2 + 4 + 8 = 15
assert_eq!(out[&root].files, 15);
assert_eq!(out[&root.join("a")].files, 6);
assert_eq!(out[&root.join("a").join("b")].files, 4);
assert_eq!(out[&root.join("c")].files, 8);
// values() の合計 = 33 ≠ 15
```

このクレートの**他の 5 つのテストはすべて `map.get(&root)` を読んでいます**。パリティテストだけが規約を破っていました。

## 2. `--mft` がロールアップを飛ばしていた（実バグ）

```rust
// lib.rs:567 — 修正前
if let Some(map) = platform::scan_volume_via_mft(root, opt) {
    return Ok(map);   // ロールアップを通らない
}
```

`to_stat_map` はファイルを**直近の親にだけ**計上します。これは歩く側のバックエンドがロールアップ前に作るものと同じ形で、そのまま返すと**呼び出し側はどちらが走ったかで意味の違うマップを受け取ります**。

| 経路 | ディレクトリの報告サイズ |
|---|---|
| 既定（列挙） | 部分木の合計 |
| `--mft` | **そのディレクトリ自身の分だけ** |

**2 が実バグで、1 がそれを覆い隠していました。**

## 決め手

`fsutil fsinfo ntfsinfo` が決着をつけました。

```
fsutil:  Mft Valid Data Length : 1.29 GB
本実装:  337,600 クラスタ × 4096 = 1.29 GB   ← 一致
```

1KB/レコードで約 135 万レコードなので、列挙側の 1,021 万は成立しません。**どちらかが 9 倍ずれているのではなく、両者が違う単位で報告されていました。**

## 変更点

| ファイル | 変更 |
|---|---|
| `hyperdu-core/src/lib.rs` | MFT 経路にも `rollup_child_to_parent` を適用 |
| `hyperdu-core/tests/mft_parity.rs` | `values().sum()` → `map.get(root)`、`#[ignore]` を解除 |

**`use_mft` は既定 `false` なので、既定経路の挙動は変わりません。**

## `#[ignore]` を外しました

**修正が効いたかを答えられるのは実ボリュームでの検証だけ**で、CI の Windows ランナーは昇格しているため実際に走ります。この PR の CI がそのまま検証になります。

## 検証

- `cargo test`: ワークスペース全体で通過（`mft_parity` 3 件を含む）
- `cargo clippy --all-targets`: 警告 0 件

## 経緯から残したいこと

この調査では**推定が 3 回外れました**。

1. 「`$ATTRIBUTE_LIST` の未追跡で MFT が取りこぼしている」→ 修正しても 88.90% → 88.88% で変化なし
2. 「列挙側が 9 倍に過大計上している」→ どちらも正しかった
3. 実際は**テストの比較方法**と**MFT 経路のロールアップ漏れ**

**段階ごとの数値を出し、`fsutil` という外部の裏付けを取って初めて向きが分かりました。** 最終結果の数字だけを見て原因を推定したのが誤りでした。

テストの doc コメントに、この教訓と `fsutil` による切り分け方を残してあります。次に失敗した人が同じ道を辿らないように。
