### PR TITLE
diag: 物理サイズの残差 6.1 GB の原因候補を数える（#41 / 計測のみ）

### DIFF
--- a/hyperdu-core/src/platform/windows_impl/mft_reader.rs
+++ b/hyperdu-core/src/platform/windows_impl/mft_reader.rs
@@ -51,10 +51,41 @@ pub(crate) struct Entry {
     pub(crate) hard_link_count: u16,
     /// `$DATA` attribute flags: compressed, sparse, encrypted. Kept because the
     /// allocated size means something different for each, and the MFT and the
-    /// enumeration API disagree by 37% on a real volume (#39) -- which of those
-    /// categories the difference sits in is a question only measurement
-    /// answers.
+    /// enumeration API disagreed by 37% on a real volume until each was read
+    /// its own way (#39).
     pub(crate) data_flags: u16,
+    /// Why this record's sizes are what they are. The MFT still reports 6.1 GB
+    /// less than enumeration (#41) and the candidate causes are distinguishable
+    /// only by counting them: guessing which one dominates is how #39 went
+    /// wrong twice.
+    pub(crate) size_source: SizeSource,
+}
+
+/// Where a record's sizes came from, and what else it carries that could
+/// account for a discrepancy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SizeSource {
+    /// False when no `$DATA` was found in the base record and the stale copy in
+    /// `$FILE_NAME` had to stand in.
+    pub(crate) from_data_attribute: bool,
+    /// The record has an `$ATTRIBUTE_LIST`, so some of its attributes --
+    /// possibly the rest of `$DATA` -- live in extension records that this
+    /// reader does not follow for ordinary files.
+    pub(crate) has_attribute_list: bool,
+    /// Bytes in named `$DATA` streams beyond the first. `du` does not count
+    /// these; the enumeration API may. WOF-compressed files keep their real
+    /// contents here.
+    pub(crate) named_stream_bytes: u64,
+}
+
+impl Default for SizeSource {
+    fn default() -> Self {
+        Self {
+            from_data_attribute: true,
+            has_attribute_list: false,
+            named_stream_bytes: 0,
+        }
+    }
 }
 
 /// Reads records from the `$MFT` of a volume.
@@ -229,6 +260,7 @@ impl<S: VolumeSource> MftReader<S> {
         let mut names: Vec<FileName> = Vec::new();
         let mut sizes: Option<DataSizes> = None;
         let mut data_flags: u16 = 0;
+        let mut source = SizeSource::default();
         for attr in Attributes::new(&rec, &header) {
             match attr.type_code {
                 attr_type::FILE_NAME if !attr.non_resident => {
@@ -239,14 +271,24 @@ impl<S: VolumeSource> MftReader<S> {
                     }
                 }
                 // The first $DATA is the file's contents. A later one is a
-                // named alternate stream, which `du` does not count.
+                // named alternate stream, which `du` does not count -- but its
+                // bytes are measured anyway, because the enumeration API may be
+                // counting them and that would explain part of #41.
                 attr_type::DATA if sizes.is_none() => {
                     sizes = parse_data_sizes(&rec, &attr, self.geometry.cluster_size());
                     data_flags = attr.flags;
                 }
+                attr_type::DATA => {
+                    if let Some(s) = parse_data_sizes(&rec, &attr, self.geometry.cluster_size()) {
+                        source.named_stream_bytes =
+                            source.named_stream_bytes.saturating_add(s.allocated_size);
+                    }
+                }
+                attr_type::ATTRIBUTE_LIST => source.has_attribute_list = true,
                 _ => {}
             }
         }
+        source.from_data_attribute = sizes.is_some();
 
         let links = distinct_links(&names);
         // Prefer a Win32 name for display; a POSIX-only record still has one.
@@ -268,6 +310,7 @@ impl<S: VolumeSource> MftReader<S> {
             }),
             hard_link_count: header.hard_link_count,
             data_flags,
+            size_source: source,
         })
     }
 
@@ -929,6 +972,7 @@ mod tests {
             },
             hard_link_count: 1,
             data_flags: 0,
+            size_source: SizeSource::default(),
         }
     }
 

--- a/hyperdu-core/src/platform/windows_impl/mod.rs
+++ b/hyperdu-core/src/platform/windows_impl/mod.rs
@@ -143,6 +143,33 @@ pub fn scan_volume_via_mft(root: &std::path::Path, opt: &crate::Options) -> Opti
                 )
             });
         eprintln!("mft-diag: allocated > 2x real -- {over_n} files, {over_bytes} bytes of excess");
+
+        // The three candidate causes of the remaining 6.1 GB gap (#41), counted
+        // rather than guessed at. Whichever carries the bytes is the one to fix.
+        let mut stale = (0u64, 0u64);
+        let mut listed = (0u64, 0u64);
+        let mut named = (0u64, 0u64);
+        for e in entries.iter().filter(|e| !e.is_directory) {
+            let s = &e.size_source;
+            if !s.from_data_attribute {
+                stale.0 += 1;
+                stale.1 = stale.1.saturating_add(e.sizes.allocated_size);
+            }
+            if s.has_attribute_list {
+                listed.0 += 1;
+                listed.1 = listed.1.saturating_add(e.sizes.allocated_size);
+            }
+            if s.named_stream_bytes > 0 {
+                named.0 += 1;
+                named.1 = named.1.saturating_add(s.named_stream_bytes);
+            }
+        }
+        eprintln!(
+            "mft-diag: gap candidates -- $FILE_NAME fallback: {} files {} bytes | \
+             has $ATTRIBUTE_LIST: {} files {} bytes | \
+             named streams: {} files {} bytes (not counted)",
+            stale.0, stale.1, listed.0, listed.1, named.0, named.1
+        );
     }
 
     Some(map)


### PR DESCRIPTION
#41（`--mft` の物理サイズが列挙より 6.1 GB 少ない）の**原因候補を数えるための計測**です。まだ修正ではありません。

## なぜ先に測るのか

#39 では**推定が 2 回外れました**。

| 読み方 | 結果 |
|---|---|
| 0x28 | +33.35%（過大） |
| 0x40 | -7.47%（過少） |
| 実行リスト | **-5.41%** |

「スパースは 0x40 を読めばよい」という一見もっともらしい推定が、実測で否定されました。**そのフィールドはスパースなだけの属性には存在しなかった**からです。

同じ轍を踏まないよう、残る 6.1 GB も**数えてから直します**。

## 追加した計測

`Entry` に `SizeSource` を持たせ、記録ごとに次を捕まえます。

| フィールド | 意味 |
|---|---|
| `from_data_attribute` | 基底レコードに `$DATA` が無く、**`$FILE_NAME` の古いコピーで代用したか** |
| `has_attribute_list` | `$ATTRIBUTE_LIST` を持つか（`$DATA` の残りが拡張レコードにある可能性） |
| `named_stream_bytes` | **2 つ目以降の `$DATA`**（名前付きストリーム）の合計 |

`HYPERDU_MFT_DIAG` を立てると次が出ます。

```
mft-diag: gap candidates -- $FILE_NAME fallback: N files X bytes |
          has $ATTRIBUTE_LIST: N files X bytes |
          named streams: N files X bytes (not counted)
```

**名前付きストリームは `du` の方針で数えていませんが、列挙 API は数えているかもしれません。** WOF 圧縮（Compact OS）のファイルは実データをそこに置くので、有力候補です。

## 挙動への影響

- **既定では 1 行も出力しません**（`HYPERDU_MFT_DIAG` 設定時のみ）
- **サイズの算出は無変更**。走査ロジック・戻り値も無変更
- 出すのは件数とバイト数のみで、**ファイル名やパスは出しません**

## 検証

- `cargo test`: 142 件通過（`hyperdu-core`）、ワークスペース全体で通過
- `cargo clippy --all-targets`: 警告 0 件
- **CI の昇格した Windows ランナーが内訳を出します**

## 次の段

CI の出力を見て、バイト数を持っている候補を特定してから直します。

- `$FILE_NAME` フォールバックが支配的なら → `entry()` で `$ATTRIBUTE_LIST` を辿る（`$MFT` 用の実装が流用できるはず）
- 名前付きストリームが支配的なら → `du` の方針を見直すか、列挙側と揃える判断が要る
