### PR TITLE
fix: Skill と Plugin にセットアップを同梱し、誤ったコマンド名を直す（#45）

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,0 +1,93 @@
+# HyperDU for agents
+
+Disk usage an agent can act on: which volume is short, what is large on it, and
+which of that can be deleted without losing anything.
+
+## What is in here
+
+| Path | Format | What it is |
+|---|---|---|
+| `plugin.json` | [Agent Plugins](https://agent-plugins.org/) | The bundle manifest |
+| `mcp.json` | [Agent Plugins](https://agent-plugins.org/) | Declares the `hyperdu-mcp` stdio server |
+| `skills/disk-space-triage/` | [Agent Skills](https://agentskills.io/) | The triage procedure, driving the CLI |
+| `skills/disk-space-triage/scripts/` | — | Setup for both binaries and the MCP server |
+
+The three surfaces are independent on purpose. The MCP server runs without the
+plugin, and the skill drives `hyperdu-cli` rather than the server, so **you can
+adopt any one of them without the other two**.
+
+## Setup
+
+Everything here needs at least one HyperDU binary, and there is no prebuilt
+release yet — installation builds from source, so a
+[Rust toolchain](https://rustup.rs) is required.
+
+The bundled script installs both binaries and shows you how to register the MCP
+server:
+
+```bash
+skills/disk-space-triage/scripts/setup-hyperdu.sh
+```
+
+```powershell
+.\skills\disk-space-triage\scripts\setup-hyperdu.ps1
+```
+
+| Flag | Effect |
+|---|---|
+| *(none)* | Install what is missing, print the registration command |
+| `--check` | Report what is installed, change nothing |
+| `--register` | Install, then register with any detected client |
+
+Registration is opt-in because it rewrites an agent's configuration. Installing
+a binary is undone with `cargo uninstall`; quietly editing someone's client
+config is not something a setup script should do uninvited.
+
+### Doing it by hand
+
+```bash
+cargo install --git https://github.com/automationjp/HyperDiskUsage hyperdu-cli
+cargo install --git https://github.com/automationjp/HyperDiskUsage hyperdu-mcp
+```
+
+The binary is `hyperdu-cli`, not `hyperdu`. The shorter name exists only in the
+deb and rpm packages, which rename it on install.
+
+Then register the MCP server with your client:
+
+```bash
+claude mcp add --transport stdio hyperdu -- hyperdu-mcp
+```
+
+```bash
+codex mcp add hyperdu -- hyperdu-mcp
+```
+
+For any other MCP client, add a stdio server whose command is `hyperdu-mcp` —
+which is exactly what `mcp.json` already declares.
+
+## The MCP tools
+
+| Tool | Answers |
+|---|---|
+| `list_volumes` | Which volume is short on space |
+| `scan_path` | What is large inside a directory tree |
+| `find_reclaimable` | Which of it can be rebuilt rather than lost |
+
+`find_reclaimable` takes `unused_for_days`. Pass 1 or more before proposing any
+deletion: a directory an in-progress build is writing to is never idle, so that
+filter is what keeps a suggestion from destroying a running job.
+
+**There is no delete tool, deliberately.** These report; a human decides. A
+wrong report can be corrected, a wrong `rm -rf` cannot.
+
+## Using only the skill
+
+Copy `skills/disk-space-triage/` anywhere your agent looks for skills. It needs
+`hyperdu-cli` and nothing else from this directory — not the MCP server, not the
+plugin manifest.
+
+## Using only the MCP server
+
+Install `hyperdu-mcp`, register it, and ignore the rest of this directory. Any
+MCP client works: the server speaks stdio and holds no state between calls.

--- a/plugin/skills/disk-space-triage/SKILL.md
+++ b/plugin/skills/disk-space-triage/SKILL.md
@@ -2,7 +2,7 @@
 name: disk-space-triage
 description: Find out why a disk is full and what can safely be freed, using the HyperDU scanner. Use when a drive is out of space, a build fails with "no space left on device", or the user asks what is using their disk, which directories are largest, or what is safe to delete. Covers per-volume free space, largest-directory scans, and separating regenerable build output (Cargo target, node_modules, virtualenvs) from data that cannot be rebuilt.
 license: MIT
-compatibility: Requires the hyperdu CLI on PATH. Works on Windows, Linux, and macOS.
+compatibility: Requires the hyperdu-cli binary. Run scripts/setup-hyperdu.sh (or setup-hyperdu.ps1 on Windows) to install it; that needs a Rust toolchain, because HyperDU has no prebuilt release. Works on Windows, Linux, and macOS.
 metadata:
   project: HyperDiskUsage
   repository: https://github.com/automationjp/HyperDiskUsage
@@ -13,11 +13,37 @@ metadata:
 Answer "why is the disk full and what can I delete" in a fixed order. Skipping
 a step is what produces confident wrong answers.
 
-This skill drives the `hyperdu` CLI. It does not need the HyperDU MCP server —
+This skill drives the `hyperdu-cli` command. It does not need the MCP server —
 if that server is available, its `list_volumes`, `scan_path`, and
 `find_reclaimable` tools do the same work with typed arguments and structured
 results, and you should prefer them. This file is the fallback that works with
 nothing but a shell.
+
+## Setup
+
+The binary is called `hyperdu-cli`. If it is not on PATH, install it before
+doing anything else:
+
+```bash
+scripts/setup-hyperdu.sh
+```
+
+On Windows:
+
+```powershell
+.\scripts\setup-hyperdu.ps1
+```
+
+The script installs `hyperdu-cli` and the `hyperdu-mcp` server, then prints the
+command to register the MCP server with Claude Code or Codex. It only performs
+that registration when passed `--register`, because rewriting an agent's
+configuration should be something the user asked for.
+
+HyperDU has no prebuilt release and is not on crates.io, so the script builds
+from source and needs a Rust toolchain. If `cargo` is missing it will say so and
+point at <https://rustup.rs> rather than failing halfway through.
+
+To check without installing anything, use `--check`.
 
 ## The one rule
 
@@ -41,7 +67,7 @@ now, while one at 85% does not.
 ## Step 2 — What is large on it?
 
 ```bash
-hyperdu /path/to/volume --top 20
+hyperdu-cli /path/to/volume --top 20
 ```
 
 Read the output as a tree: HyperDU rolls sizes up, so a parent's size includes
@@ -63,7 +89,7 @@ will change.
 Scanning a full 930 GB disk with 4 million files takes roughly 47 seconds. Use
 `--max-depth` if you need an answer sooner.
 
-Check `hyperdu --help` before inventing a flag. Guessing at one costs a full
+Check `hyperdu-cli --help` before inventing a flag. Guessing at one costs a full
 scan to discover it does not exist.
 
 ## Step 3 — Drill into the largest subtree

--- a/plugin/skills/disk-space-triage/scripts/setup-hyperdu.ps1
+++ b/plugin/skills/disk-space-triage/scripts/setup-hyperdu.ps1
@@ -1,0 +1,206 @@
+<#
+.SYNOPSIS
+    Install the HyperDU binaries this skill needs, and register the MCP server.
+
+.DESCRIPTION
+    HyperDU has no published release and is not on crates.io, so `cargo install`
+    from source is the only way in. That is worth stating plainly rather than
+    leaving someone to discover it after a failed `winget install`.
+
+    Registering an MCP server rewrites an agent's configuration, so this prints
+    the command by default and only runs it when asked with -Register.
+    Installing a binary is reversible with `cargo uninstall`; silently editing
+    someone's agent config is the kind of surprise that makes a setup script
+    untrustworthy.
+
+.PARAMETER Check
+    Report what is installed and change nothing.
+
+.PARAMETER Register
+    After installing, register the MCP server with any detected client.
+
+.EXAMPLE
+    .\setup-hyperdu.ps1
+    Install what is missing and print how to register the MCP server.
+
+.EXAMPLE
+    .\setup-hyperdu.ps1 -Register
+    Install, then register with the detected clients.
+#>
+[CmdletBinding()]
+param(
+    [switch]$Check,
+    [switch]$Register
+)
+
+$ErrorActionPreference = 'Stop'
+
+$RepoUrl = 'https://github.com/automationjp/HyperDiskUsage'
+# The binary is `hyperdu-cli`, not `hyperdu`: the crate declares no [[bin]], so
+# cargo names it after the package. Only the deb/rpm packaging renames it.
+$CliBin = 'hyperdu-cli'
+$McpBin = 'hyperdu-mcp'
+$McpName = 'hyperdu'
+
+function Test-Installed {
+    param([string]$Name)
+    $null -ne (Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Get-InstalledPath {
+    param([string]$Name)
+    (Get-Command $Name -ErrorAction SilentlyContinue).Source
+}
+
+# Resolve the repository root when this script is run from inside a checkout, so
+# a contributor testing local changes installs those rather than whatever is on
+# the default branch. Layout: <root>\plugin\skills\<skill>\scripts\<this file>.
+function Get-RepoRoot {
+    $candidate = Resolve-Path (Join-Path $PSScriptRoot '..\..\..\..') -ErrorAction SilentlyContinue
+    if (-not $candidate) { return $null }
+    $manifest = Join-Path $candidate 'Cargo.toml'
+    if (-not (Test-Path $manifest)) { return $null }
+    if (-not (Select-String -Path $manifest -Pattern 'hyperdu-core' -Quiet)) { return $null }
+    return $candidate.Path
+}
+
+function Write-BinaryReport {
+    foreach ($bin in @($CliBin, $McpBin)) {
+        if (Test-Installed $bin) {
+            Write-Host "  present: $bin ($(Get-InstalledPath $bin))"
+        }
+        else {
+            Write-Host "  MISSING: $bin"
+        }
+    }
+}
+
+Write-Host 'HyperDU setup'
+Write-Host ''
+Write-Host 'Binaries:'
+Write-BinaryReport
+Write-Host ''
+
+if ($Check) {
+    if ((Test-Installed $CliBin) -and (Test-Installed $McpBin)) { exit 0 }
+    Write-Host 'Run this script without -Check to install what is missing.'
+    exit 1
+}
+
+$missing = @($CliBin, $McpBin) | Where-Object { -not (Test-Installed $_) }
+
+if ($missing.Count -gt 0) {
+    if (-not (Test-Installed 'cargo')) {
+        Write-Error @'
+cargo not found, and HyperDU has no prebuilt release to fall back on.
+
+Install a Rust toolchain first:
+  https://rustup.rs
+
+Then run this script again.
+'@
+        exit 1
+    }
+
+    $root = Get-RepoRoot
+    if ($root) {
+        Write-Host "Installing from this checkout: $root"
+    }
+    else {
+        Write-Host "Installing from $RepoUrl"
+    }
+
+    foreach ($bin in $missing) {
+        Write-Host ''
+        if ($root) {
+            $crateDir = Join-Path $root $bin
+            Write-Host "==> cargo install --path $crateDir"
+            & cargo install --path $crateDir
+        }
+        else {
+            Write-Host "==> cargo install --git $RepoUrl $bin"
+            & cargo install --git $RepoUrl $bin
+        }
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "cargo install failed for $bin"
+            exit 1
+        }
+    }
+
+    # cargo appends ~/.cargo/bin to the user PATH on first install, but this
+    # process inherited its environment before that happened. Without the
+    # refresh the freshly installed binaries report as missing and the next
+    # step looks broken.
+    $userPath = [System.Environment]::GetEnvironmentVariable('PATH', 'User')
+    if ($userPath) { $env:PATH = "$userPath;$env:PATH" }
+
+    Write-Host ''
+    Write-Host 'Binaries after install:'
+    Write-BinaryReport
+    Write-Host ''
+
+    if (-not (Test-Installed $CliBin) -or -not (Test-Installed $McpBin)) {
+        Write-Warning @'
+cargo finished but the binaries are not on PATH.
+They are in %USERPROFILE%\.cargo\bin. Add it to PATH, for example:
+
+  $env:PATH = "$env:USERPROFILE\.cargo\bin;$env:PATH"
+
+'@
+    }
+}
+
+# --- MCP registration -------------------------------------------------------
+#
+# Installing the server binary is not enough: a client only sees it once it has
+# been registered.
+
+Write-Host 'MCP server registration:'
+
+function Invoke-ClientRegistration {
+    param(
+        [string]$Client,
+        [string[]]$Arguments
+    )
+    if (-not (Test-Installed $Client)) { return $false }
+
+    $display = "$Client $($Arguments -join ' ')"
+    if ($Register) {
+        Write-Host "  ==> $display"
+        & $Client @Arguments
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "  registered with $Client"
+        }
+        else {
+            Write-Warning "  $Client registration failed; run the command above by hand"
+        }
+    }
+    else {
+        Write-Host "  $Client detected. To register:"
+        Write-Host "    $display"
+    }
+    return $true
+}
+
+$claudeFound = Invoke-ClientRegistration -Client 'claude' `
+    -Arguments @('mcp', 'add', '--transport', 'stdio', $McpName, '--', $McpBin)
+$codexFound = Invoke-ClientRegistration -Client 'codex' `
+    -Arguments @('mcp', 'add', $McpName, '--', $McpBin)
+
+if (-not ($claudeFound -or $codexFound)) {
+    Write-Host @"
+  No claude or codex CLI found on PATH.
+
+  For any other MCP client, add a stdio server that runs:
+    $McpBin
+
+  The bundled plugin/mcp.json already declares exactly that.
+"@
+}
+elseif (-not $Register) {
+    Write-Host ''
+    Write-Host 'Re-run with -Register to have this script issue those commands.'
+}
+
+Write-Host ''
+Write-Host 'Done.'

--- a/plugin/skills/disk-space-triage/scripts/setup-hyperdu.sh
+++ b/plugin/skills/disk-space-triage/scripts/setup-hyperdu.sh
@@ -1,0 +1,181 @@
+#!/bin/sh
+# Install the HyperDU binaries this skill needs, and register the MCP server.
+#
+# HyperDU has no published release and is not on crates.io, so `cargo install`
+# from source is the only way in. That is worth stating plainly rather than
+# leaving someone to discover it after a failed `apt install`.
+#
+# Registering an MCP server rewrites an agent's configuration, so this prints
+# the command by default and only runs it when asked with --register. Installing
+# a binary is reversible with `cargo uninstall`; silently editing someone's
+# agent config is the kind of surprise that makes a setup script untrustworthy.
+#
+#   ./setup-hyperdu.sh              install what is missing, print how to register
+#   ./setup-hyperdu.sh --check      report status, change nothing
+#   ./setup-hyperdu.sh --register   install, then register with detected clients
+
+set -eu
+
+REPO_URL="https://github.com/automationjp/HyperDiskUsage"
+# The binary is `hyperdu-cli`, not `hyperdu`: the crate declares no [[bin]], so
+# cargo names it after the package. Only the deb/rpm packaging renames it.
+CLI_BIN="hyperdu-cli"
+MCP_BIN="hyperdu-mcp"
+MCP_NAME="hyperdu"
+
+MODE="install"
+
+for arg in "$@"; do
+    case "$arg" in
+        --check) MODE="check" ;;
+        --register) MODE="register" ;;
+        -h | --help)
+            sed -n '2,15p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "unknown option: $arg" >&2
+            echo "try --help" >&2
+            exit 2
+            ;;
+    esac
+done
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+# Resolve the repository root when this script is run from inside a checkout, so
+# a contributor testing local changes installs those rather than whatever is on
+# the default branch. Layout: <root>/plugin/skills/<skill>/scripts/<this file>.
+repo_root() {
+    script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+    candidate=$(CDPATH= cd -- "$script_dir/../../../.." 2>/dev/null && pwd) || return 1
+    [ -f "$candidate/Cargo.toml" ] || return 1
+    grep -q 'hyperdu-core' "$candidate/Cargo.toml" || return 1
+    printf '%s' "$candidate"
+}
+
+report() {
+    for bin in "$CLI_BIN" "$MCP_BIN"; do
+        if have "$bin"; then
+            echo "  present: $bin ($(command -v "$bin"))"
+        else
+            echo "  MISSING: $bin"
+        fi
+    done
+}
+
+echo "HyperDU setup"
+echo
+echo "Binaries:"
+report
+echo
+
+if [ "$MODE" = "check" ]; then
+    if have "$CLI_BIN" && have "$MCP_BIN"; then
+        exit 0
+    fi
+    echo "Run this script without --check to install what is missing."
+    exit 1
+fi
+
+missing=""
+have "$CLI_BIN" || missing="$missing $CLI_BIN"
+have "$MCP_BIN" || missing="$missing $MCP_BIN"
+
+if [ -n "$missing" ]; then
+    if ! have cargo; then
+        cat >&2 <<'EOF'
+error: cargo not found, and HyperDU has no prebuilt release to fall back on.
+
+Install a Rust toolchain first:
+  https://rustup.rs
+
+Then run this script again.
+EOF
+        exit 1
+    fi
+
+    if root=$(repo_root); then
+        echo "Installing from this checkout: $root"
+        from_checkout=1
+    else
+        echo "Installing from $REPO_URL"
+        from_checkout=0
+    fi
+
+    for bin in $missing; do
+        echo
+        if [ "$from_checkout" -eq 1 ]; then
+            echo "==> cargo install --path $root/$bin"
+            cargo install --path "$root/$bin"
+        else
+            echo "==> cargo install --git $REPO_URL $bin"
+            cargo install --git "$REPO_URL" "$bin"
+        fi
+    done
+
+    echo
+    echo "Binaries after install:"
+    report
+    echo
+
+    # cargo installs into ~/.cargo/bin, which a shell started before the
+    # toolchain existed may not have on PATH. Without this note the next step
+    # fails for a reason that looks like the install itself did not work.
+    if ! have "$CLI_BIN" || ! have "$MCP_BIN"; then
+        cat >&2 <<'EOF'
+warning: cargo finished but the binaries are not on PATH.
+They are in ~/.cargo/bin. Add it to PATH, for example:
+
+  export PATH="$HOME/.cargo/bin:$PATH"
+
+EOF
+    fi
+fi
+
+# --- MCP registration -------------------------------------------------------
+#
+# Installing the server binary is not enough: a client only sees it once it has
+# been registered.
+
+echo "MCP server registration:"
+
+found_client=0
+
+register_with() {
+    client=$1
+    shift
+    have "$client" || return 0
+    found_client=1
+    if [ "$MODE" = "register" ]; then
+        echo "  ==> $*"
+        if "$@"; then
+            echo "  registered with $client"
+        else
+            echo "  WARNING: $client registration failed; run the command above by hand" >&2
+        fi
+    else
+        echo "  $client detected. To register:"
+        echo "    $*"
+    fi
+}
+
+register_with claude claude mcp add --transport stdio "$MCP_NAME" -- "$MCP_BIN"
+register_with codex codex mcp add "$MCP_NAME" -- "$MCP_BIN"
+
+if [ "$found_client" -eq 0 ]; then
+    cat <<EOF
+  No claude or codex CLI found on PATH.
+
+  For any other MCP client, add a stdio server that runs:
+    $MCP_BIN
+
+  The bundled plugin/mcp.json already declares exactly that.
+EOF
+elif [ "$MODE" != "register" ]; then
+    echo
+    echo "Re-run with --register to have this script issue those commands."
+fi
+
+echo
+echo "Done."


### PR DESCRIPTION
#45 の修正です。#43 で入れた Skill と Plugin は **HyperDU が既に入っている前提**で、導入手段を持っていませんでした。

## 見つかったバグ

`hyperdu-cli/Cargo.toml` に `[[bin]]` が無いため、**`cargo install` が作るバイナリは `hyperdu-cli`** です。`hyperdu` という名前は deb/rpm パッケージ側のリネーム（`hyperdu-cli/Cargo.toml:72`）でしか存在しません。

ところが SKILL.md は全編で `hyperdu /path --top 20` と書いていました。**`cargo install` で入れた環境では Skill が丸ごと動きません。**

実測で確認しました。

```
Installing C:\Users\syska\.cargo\bin\hyperdu-cli.exe
```

前回の PR でこれを見落としていました。今回は**実際にインストールして動作確認**しています。

## セットアップスクリプト

`plugin/skills/disk-space-triage/scripts/` に `setup-hyperdu.sh` と `.ps1` を追加しました。Agent Skills 仕様の `scripts/` 規約に置いているので、**Skill フォルダをコピーするだけで単独利用できる形**を保っています。

| フラグ | 動作 |
|---|---|
| *(なし)* | 不足分を導入し、登録コマンドを表示 |
| `--check` | 状態を報告するだけ（何も変更しない） |
| `--register` | 導入後、検出したクライアントに登録まで行う |

配布状況を確認したところ、**公開リリースが無く（v0.0.1 は Draft）、crates.io にも未公開**でした。したがって `cargo install` からソースビルドする以外に道がありません。cargo が無ければ **rustup を案内して停止**します（途中まで進んで失敗させない）。

リポジトリ内から実行された場合は `cargo install --path`、外なら `cargo install --git` を使います。開発者がローカルの変更を試せるようにするためです。

## MCP サーバの登録

**バイナリを入れただけではクライアントから見えません。** 登録まで面倒を見ます。構文は実機で確認しました。

```bash
claude mcp add --transport stdio hyperdu -- hyperdu-mcp
codex mcp add hyperdu -- hyperdu-mcp
```

**既定では実行せず、コマンドを表示するだけ**にしました。`--register` を付けたときだけ実行します。バイナリの導入は `cargo uninstall` で戻せますが、利用者のエージェント設定を黙って書き換えるのは戻せる戻せない以前に筋が悪いためです。

どちらの CLI も無い環境では、`mcp.json` が同じ内容を宣言していることを案内します。

## `plugin/README.md`

Skill を経由せず Plugin から入る利用者向けに、同じ手順を独立して書きました。**Skill の内部に依存させていない**ので、疎結合は維持しています。

## 検証

すべて実機で実行しました。

**スクリプト**

```
sh -n setup-hyperdu.sh         → OK
setup-hyperdu.sh --help        → 使い方を表示
setup-hyperdu.sh --check       → MISSING を報告、exit 1
setup-hyperdu.sh               → 両バイナリを導入、claude と codex を検出、
                                 登録コマンドを表示、登録はしない（正しい既定）
```

**導入した CLI**

```
--top / --json / --csv / --max-depth  → 4 つとも実在を確認
hyperdu-cli <path> --top 3            → 実際に走査できることを確認
```

**導入した MCP サーバ**

```
PATH 上の hyperdu-mcp に JSON-RPC を流し、list_volumes が
実ドライブ（C: / F: / D:）を使用率つきで返すことを確認
```

## 残っている限界

**公開リリースが無いことは解決していません。** ソースビルドを要求する以上、Rust ツールチェーンの無い利用者は使えません。バイナリ配布は `packaging/` と `.github/workflows/release.yml` が既に用意されているので、**タグを打ってリリースを公開すれば解消できます**。これは別途ご判断ください。

Refs #45
