### PR TITLE
diag: 名前付きストリームを無名 $DATA の空/非空で割る（#41 / 計測のみ）

### DIFF
--- a/hyperdu-core/src/platform/windows_impl/mod.rs
+++ b/hyperdu-core/src/platform/windows_impl/mod.rs
@@ -149,8 +149,21 @@ pub fn scan_volume_via_mft(root: &std::path::Path, opt: &crate::Options) -> Opti
         let mut stale = (0u64, 0u64);
         let mut listed = (0u64, 0u64);
         let mut named = (0u64, 0u64);
+        // Named streams split by whether the unnamed $DATA is empty. Counting
+        // all 16.4 GB of named streams would overshoot a 6.1 GB gap by ten, so
+        // enumeration cannot be counting all of them. The suspected dividing
+        // line is WOF compression (Compact OS): those files park their real
+        // contents in a `WofCompressedData` stream and leave the unnamed $DATA
+        // empty, and Windows reports the compressed bytes as the file's size.
+        // An ordinary alternate data stream sits beside a non-empty $DATA and
+        // is a different case. If the first bucket lands near 6.1 GB the split
+        // is the answer; if it does not, this rules the theory out cheaply.
+        let mut wof_like = (0u64, 0u64);
+        let mut ads_like = (0u64, 0u64);
+        let mut file_bytes: u64 = 0;
         for e in entries.iter().filter(|e| !e.is_directory) {
             let s = &e.size_source;
+            file_bytes = file_bytes.saturating_add(e.sizes.allocated_size);
             if !s.from_data_attribute {
                 stale.0 += 1;
                 stale.1 = stale.1.saturating_add(e.sizes.allocated_size);
@@ -162,6 +175,16 @@ pub fn scan_volume_via_mft(root: &std::path::Path, opt: &crate::Options) -> Opti
             if s.named_stream_bytes > 0 {
                 named.0 += 1;
                 named.1 = named.1.saturating_add(s.named_stream_bytes);
+
+                // Only meaningful when the size really came from $DATA; a
+                // $FILE_NAME fallback says nothing about the unnamed stream.
+                let bucket = if s.from_data_attribute && e.sizes.allocated_size == 0 {
+                    &mut wof_like
+                } else {
+                    &mut ads_like
+                };
+                bucket.0 += 1;
+                bucket.1 = bucket.1.saturating_add(s.named_stream_bytes);
             }
         }
         eprintln!(
@@ -169,6 +192,19 @@ pub fn scan_volume_via_mft(root: &std::path::Path, opt: &crate::Options) -> Opti
              has $ATTRIBUTE_LIST: {} files {} bytes | \
              named streams: {} files {} bytes (not counted)",
             stale.0, stale.1, listed.0, listed.1, named.0, named.1
+        );
+        eprintln!(
+            "mft-diag: named streams split -- empty unnamed $DATA (WOF-like): {} files {} bytes | \
+             non-empty unnamed $DATA (ordinary ADS): {} files {} bytes",
+            wof_like.0, wof_like.1, ads_like.0, ads_like.1
+        );
+        // Printed together so one CI run answers "which total matches
+        // enumeration" without arithmetic across three log lines.
+        eprintln!(
+            "mft-diag: file bytes -- as reported: {} | plus WOF-like: {} | plus all named: {}",
+            file_bytes,
+            file_bytes.saturating_add(wof_like.1),
+            file_bytes.saturating_add(named.1)
         );
     }
 


### PR DESCRIPTION
#41 の**仮説を検証するための計測**です。まだ修正ではありません。

## 前回わかったこと

3 つの候補を数えた結果、名前付きストリームが圧倒的でした。

| 候補 | ファイル数 | バイト数 |
|---|---|---|
| `$FILE_NAME` フォールバック | 6,443 | 0.9 GB |
| `$ATTRIBUTE_LIST` を持つ | 3,221 | 1.0 GB |
| **名前付きストリーム** | **108,152** | **16.4 GB** |

## ただし、そのまま足すと合いません

差は **6.1 GB** です。**16.4 GB を全部足すと 10 GB 超過します。** つまり列挙 API は名前付きストリームを全部数えているわけではありません。

「名前付きストリームが原因だから足せばいい」で進めていたら、#39 と同じ失敗（推定が 2 回外れた）を繰り返すところでした。

## 仮説

**分かれ目は WOF 圧縮（Compact OS）ではないか。**

| | 無名 `$DATA` | 実データの置き場所 | Windows が報告するサイズ |
|---|---|---|---|
| WOF 圧縮 | **空** | `WofCompressedData` ストリーム | 圧縮後のバイト数 |
| 通常の ADS | 中身あり | 無名 `$DATA` | 無名 `$DATA` の分だけ |

108,152 という数はシステムファイルの規模と符合し、WOF 圧縮の適用範囲としても自然です。

## 追加した計測

名前付きストリームを 2 つに割って数えます。

```
mft-diag: named streams split -- empty unnamed $DATA (WOF-like): N files X bytes |
          non-empty unnamed $DATA (ordinary ADS): N files X bytes
```

**前者が 6.1 GB 近辺なら仮説どおり。外れていれば安く否定できます。**

あわせて 3 つの合計を並べます。CI の 1 回の実行で、どれが列挙側と一致するか読み取れるようにするためです。

```
mft-diag: file bytes -- as reported: X | plus WOF-like: Y | plus all named: Z
```

パリティテストが出す `enumeration: physical=...` と突き合わせます。

## 実装上の補足

**新しいフィールドは足していません。** `from_data_attribute` が真かつ `allocated_size` が 0 なら無名 `$DATA` は空、と既存の情報から導けます。

## 挙動への影響

- **既定では 1 行も出力しません**（`HYPERDU_MFT_DIAG` 設定時のみ）
- **サイズの算出・走査ロジック・戻り値は無変更**
- 出すのは件数とバイト数のみで、ファイル名やパスは出しません

## 検証

- `cargo test --workspace`: 12 スイート全通過
- `cargo clippy --workspace --all-targets`: 警告 0
- **CI の昇格した Windows ランナーが実測します**

## 次の段

CI の出力を見てから直します。

- WOF らしいものが 6.1 GB 近辺 → その条件で名前付きストリームを加算する
- そうでない → 仮説を捨て、列挙側の `AllocationSize` が何を含むかを直接測る

Refs #41
