### PR TITLE
fix: winget / scoop のマニフェストを実際に使える形にする（#50）

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,21 +162,37 @@ jobs:
       - name: Generate Scoop & winget manifests
         shell: powershell
         run: |
-          $ver = (Select-String -Path 'hyperdu-cli/Cargo.toml' -Pattern '^version\s*=\s*"([^"]+)"' | ForEach-Object { $_.Matches[0].Groups[1].Value })[0]
-          pwsh -File scripts/package_scoop.ps1 -Version $ver
-          pwsh -File scripts/package_winget.ps1 -Version $ver
-          # Fill URLs & SHA256 for scoop manifest
+          $ErrorActionPreference = 'Stop'
+          # @() matters: a single match yields a bare string, and indexing that
+          # returns its first character -- which produced a package version of
+          # "0" instead of "0.5.0-beta.1".
+          $ver = @(Select-String -Path 'hyperdu-cli/Cargo.toml' -Pattern '^version\s*=\s*"([^"]+)"' |
+            ForEach-Object { $_.Matches[0].Groups[1].Value })[0]
           $tag = "$env:GITHUB_REF_NAME"
-          $asset = Get-ChildItem dist\hyperdu-cli-windows-*.exe | Select-Object -First 1
-          if (-not $asset) { $asset = Get-ChildItem dist\hyperdu-cli-*.msi | Select-Object -First 1 }
-          if ($asset) {
-            $fname = $asset.Name
-            $url = "https://github.com/$env:GITHUB_REPOSITORY/releases/download/$tag/$fname"
-            $hash = (Get-FileHash -Algorithm SHA256 $asset.FullName).Hash.ToLower()
-            (Get-Content dist\scoop\hyperdu.json) -replace '__URL__', $url -replace '__SHA256__', $hash | Set-Content dist\scoop\hyperdu.json -Encoding UTF8
-            # Update winget manifest as well
-            (Get-Content dist\winget\manifest.yaml) -replace '__URL__', $url -replace '__SHA256__', $hash | Set-Content dist\winget\manifest.yaml -Encoding UTF8
+          $base = "https://github.com/$env:GITHUB_REPOSITORY/releases/download/$tag"
+
+          function Get-Asset($pattern) {
+            $a = Get-ChildItem $pattern -ErrorAction SilentlyContinue | Select-Object -First 1
+            if (-not $a) { throw "no release asset matched $pattern" }
+            [pscustomobject]@{
+              Url  = "$base/$($a.Name)"
+              Hash = (Get-FileHash -Algorithm SHA256 $a.FullName).Hash.ToLower()
+            }
           }
+
+          # Different assets on purpose. winget installs the bare executable as
+          # a `portable` package; Scoop extracts the zip and resolves `bin`
+          # inside it, which keeps the shim name stable.
+          $exe = Get-Asset 'dist\hyperdu-cli-windows-*.exe'
+          $zip = Get-Asset 'dist\hyperdu-cli-windows-*.zip'
+
+          pwsh -File scripts/package_winget.ps1 -Version $ver `
+            -InstallerUrl $exe.Url -InstallerSha256 $exe.Hash
+          pwsh -File scripts/package_scoop.ps1 -Version $ver `
+            -Url $zip.Url -Sha256 $zip.Hash
+
+          Write-Host "winget manifests:"
+          Get-ChildItem dist\winget | ForEach-Object { Write-Host "  $($_.Name)" }
       - name: Open PR to Scoop bucket
         env:
           GH_TOKEN: ${{ secrets.SCOOP_GH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -83,9 +83,23 @@ cargo install hyperdu-gui --version 0.5.0-beta.1
 
 **インストールされるコマンド名は `hyperdu-cli` です。** 短い `hyperdu` は deb / rpm パッケージ側でのリネームでのみ存在します。
 
+### Windows のパッケージマネージャ
+
+```powershell
+winget install automationjp.HyperDU
+```
+
+```powershell
+scoop install hyperdu
+```
+
+> **公開リリース後に有効になります。** マニフェストは `release.yml` がタグから自動生成しますが、winget は [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) への PR、scoop はバケットへの登録がそれぞれ別途必要です。現時点では未提出です。
+
 ### 事前ビルド
 
 以下は GitHub Releases の最新版への直接リンクです。ダウンロードして展開するだけで実行できます。
+
+> **現時点でリンク先は存在しません。** 公開リリースがまだ 1 つもないためです（`v0.0.1` は Draft のまま）。タグを打つと `release.yml` が production ビルドの成果物を公開します。
 
 - Windows (x86_64)
   - CLI: [hyperdu-cli-windows-x86_64-generic.zip](releases/latest/download/hyperdu-cli-windows-x86_64-generic.zip)

--- a/scripts/package_brew.sh
+++ b/scripts/package_brew.sh
@@ -25,7 +25,7 @@ mkdir -p "$outdir"
 cat >"$outdir/hyperdu.rb" <<'RUBY'
 class Hyperdu < Formula
   desc "Hyper-fast disk usage analyzer CLI"
-  homepage "https://github.com/your-org/HyperDiskUsage"
+  homepage "https://github.com/automationjp/HyperDiskUsage"
   url "__URL_TARBALL__"
   sha256 "__SHA256__"
   version "__VERSION__"

--- a/scripts/package_scoop.ps1
+++ b/scripts/package_scoop.ps1
@@ -1,23 +1,86 @@
+<#
+.SYNOPSIS
+    Generate a Scoop manifest for the HyperDU CLI.
+
+.DESCRIPTION
+    Two things in the previous version made the resulting manifest unusable:
+
+      * `bin` was `hyperdu.exe`. Cargo names the binary after the package, so
+        what ships is `hyperdu-cli.exe`; the short name exists only inside the
+        deb and rpm packages, which rename it on install. Scoop would have
+        installed the package and left no working command behind.
+      * `homepage` pointed at `github.com/your-org/HyperDiskUsage`, which does
+        not exist. Only the URL and hash were ever substituted at release time.
+
+    The download is the zip, not the bare exe: Scoop extracts the archive and
+    then resolves `bin` inside it, so the shim keeps a stable name regardless of
+    what the release asset is called.
+
+.PARAMETER Version
+    Package version. Defaults to the version in hyperdu-cli/Cargo.toml.
+
+.PARAMETER Url
+    Download URL for the x64 zip. Omitted in a local dry run.
+
+.PARAMETER Sha256
+    SHA256 of that zip, lowercase hex.
+
+.PARAMETER OutDir
+    Where to write the manifest. Defaults to dist/scoop.
+#>
 Param(
-  [string]$Version
+  [string]$Version,
+  [string]$Url,
+  [string]$Sha256,
+  [string]$OutDir = (Join-Path 'dist' 'scoop')
 )
 
-if (-not $Version) {
-  $Version = (Select-String -Path 'hyperdu-cli/Cargo.toml' -Pattern '^version\s*=\s*"([^"]+)"' | ForEach-Object { $_.Matches[0].Groups[1].Value })[0]
-}
+$ErrorActionPreference = 'Stop'
 
-$outDir = Join-Path 'dist' 'scoop'
-New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+if (-not $Version) {
+  # @() matters. With a single match the pipeline yields a bare string, and
+  # indexing a string returns its first character -- which is how this produced
+  # a package version of "0" instead of "0.5.0-beta.1".
+  $Version = @(Select-String -Path 'hyperdu-cli/Cargo.toml' -Pattern '^version\s*=\s*"([^"]+)"' |
+    ForEach-Object { $_.Matches[0].Groups[1].Value })[0]
+}
+if (-not $Version) { throw 'could not determine version from hyperdu-cli/Cargo.toml' }
+
+# Placeholders only for a local dry run; a release passes both.
+if (-not $Url) { $Url = '__URL__' }
+if (-not $Sha256) { $Sha256 = '__SHA256__' }
+
+$repo = 'https://github.com/automationjp/HyperDiskUsage'
+
+New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
 
 $manifest = [ordered]@{
-  version = $Version
-  description = 'Hyper-fast disk usage analyzer CLI'
-  homepage = 'https://github.com/your-org/HyperDiskUsage'
-  license = 'MIT'
-  architecture = @{ x64 = @{ url = '__URL__'; hash = '__SHA256__' } }
-  bin = 'hyperdu.exe'
+  version      = $Version
+  description  = 'Fast cross-platform disk usage analyzer'
+  homepage     = $repo
+  license      = 'MIT'
+  architecture = [ordered]@{
+    '64bit' = [ordered]@{
+      url  = $Url
+      hash = $Sha256
+    }
+  }
+  # Matches what cargo actually builds. See the note above.
+  bin          = 'hyperdu-cli.exe'
+  checkver     = [ordered]@{
+    github = $repo
+  }
+  autoupdate   = [ordered]@{
+    architecture = [ordered]@{
+      '64bit' = [ordered]@{
+        url = "$repo/releases/download/v`$version/hyperdu-cli-windows-x86_64-generic.zip"
+      }
+    }
+  }
 }
 
-$json = $manifest | ConvertTo-Json -Depth 5
-Set-Content -Path (Join-Path $outDir 'hyperdu.json') -Value $json -Encoding UTF8
-Write-Host "Wrote scoop manifest: $outDir/hyperdu.json"
+$json = $manifest | ConvertTo-Json -Depth 6
+$path = Join-Path $OutDir 'hyperdu.json'
+# Scoop reads these as UTF-8; a BOM trips up some tooling that consumes buckets.
+[System.IO.File]::WriteAllText($path, $json, (New-Object System.Text.UTF8Encoding($false)))
+Write-Host "Wrote scoop manifest: $path"

--- a/scripts/package_winget.ps1
+++ b/scripts/package_winget.ps1
@@ -1,34 +1,144 @@
+<#
+.SYNOPSIS
+    Generate winget manifests for the HyperDU CLI.
+
+.DESCRIPTION
+    Writes the three-file manifest set that the Windows Package Manager
+    Community Repository requires (version, installer, default locale) at
+    ManifestVersion 1.12.0.
+
+    The previous version of this script emitted a single `manifest.yaml` using
+    the pre-1.0 preview schema (`Id`, `Version`, `Name`), which today's winget
+    rejects outright. It also left `YourOrg.HyperDU` and `Your Org` in the
+    output, because the release workflow only ever substituted the URL and hash.
+
+    InstallerType is `portable`, not `exe`. The release asset is the bare
+    binary, not an installer, and winget requires every `exe` entry to support a
+    silent install. `portable` is the type meant for standalone executables:
+    winget puts a shim on PATH and can uninstall it again.
+
+.PARAMETER Version
+    Package version. Defaults to the version in hyperdu-cli/Cargo.toml.
+
+.PARAMETER InstallerUrl
+    Download URL for the x64 executable. Omitted in a local dry run.
+
+.PARAMETER InstallerSha256
+    SHA256 of that executable, lowercase hex.
+
+.PARAMETER OutDir
+    Where to write the manifests. Defaults to dist/winget.
+
+.EXAMPLE
+    pwsh -File scripts/package_winget.ps1 -Version 0.5.0-beta.1 `
+        -InstallerUrl https://example.invalid/hyperdu-cli.exe `
+        -InstallerSha256 0000000000000000000000000000000000000000000000000000000000000000
+#>
 Param(
-  [string]$Version
+  [string]$Version,
+  [string]$InstallerUrl,
+  [string]$InstallerSha256,
+  [string]$OutDir = (Join-Path 'dist' 'winget')
 )
 
+$ErrorActionPreference = 'Stop'
+
 if (-not $Version) {
-  $Version = (Select-String -Path 'hyperdu-cli/Cargo.toml' -Pattern '^version\s*=\s*"([^"]+)"' | ForEach-Object { $_.Matches[0].Groups[1].Value })[0]
+  # @() matters. With a single match the pipeline yields a bare string, and
+  # indexing a string returns its first character -- which is how this produced
+  # a package version of "0" instead of "0.5.0-beta.1".
+  $Version = @(Select-String -Path 'hyperdu-cli/Cargo.toml' -Pattern '^version\s*=\s*"([^"]+)"' |
+    ForEach-Object { $_.Matches[0].Groups[1].Value })[0]
 }
+if (-not $Version) { throw 'could not determine version from hyperdu-cli/Cargo.toml' }
 
-$outDir = Join-Path 'dist' 'winget'
-New-Item -ItemType Directory -Path $outDir -Force | Out-Null
+# Chosen deliberately: winget-pkgs keys packages by publisher folder, and that
+# folder is awkward to rename once other versions live under it.
+$PackageIdentifier = 'automationjp.HyperDU'
+$Publisher = 'automationjp'
+$RepoUrl = 'https://github.com/automationjp/HyperDiskUsage'
+$ManifestVersion = '1.12.0'
+$Locale = 'en-US'
 
-$id = 'YourOrg.HyperDU'
-$installerUrl = '__URL__'
-$sha256 = '__SHA256__'
+# Placeholders only when this runs outside a release, so a local invocation
+# still shows the shape of the output. A release always passes both.
+if (-not $InstallerUrl) { $InstallerUrl = '__URL__' }
+if (-not $InstallerSha256) { $InstallerSha256 = '__SHA256__' }
 
-$yaml = @"
-Id: $id
-Version: $Version
-Name: HyperDU
-Publisher: Your Org
-License: MIT
-InstallerType: exe
-Installers:
-  - Architecture: x64
-    InstallerUrl: $installerUrl
-    InstallerSha256: $sha256
+New-Item -ItemType Directory -Path $OutDir -Force | Out-Null
+
+$versionYaml = @"
+# yaml-language-server: `$schema=https://aka.ms/winget-manifest.version.$ManifestVersion.schema.json
+PackageIdentifier: $PackageIdentifier
+PackageVersion: "$Version"
+DefaultLocale: $Locale
+ManifestType: version
+ManifestVersion: $ManifestVersion
 "@
 
-Set-Content -Path (Join-Path $outDir 'manifest.yaml') -Value $yaml -Encoding UTF8
-Write-Host "Wrote winget manifest: $outDir/manifest.yaml"
+$installerYaml = @"
+# yaml-language-server: `$schema=https://aka.ms/winget-manifest.installer.$ManifestVersion.schema.json
+PackageIdentifier: $PackageIdentifier
+PackageVersion: "$Version"
+Platform:
+  - Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: portable
+Commands:
+  - hyperdu-cli
+ReleaseDate: $(Get-Date -Format 'yyyy-MM-dd')
+Installers:
+  - Architecture: x64
+    InstallerUrl: $InstallerUrl
+    InstallerSha256: $InstallerSha256
+ManifestType: installer
+ManifestVersion: $ManifestVersion
+"@
 
-# Optional: open PR using GitHub CLI (requires manual configuration)
-# gh repo fork microsoft/winget-pkgs --clone=false
-# gh pr create -R microsoft/winget-pkgs -t "Add HyperDU $Version" -b "Automated manifest" -B master
+# ShortDescription is capped at 256 characters by the schema, and the line
+# length guidance is 100, so this is deliberately terse.
+$localeYaml = @"
+# yaml-language-server: `$schema=https://aka.ms/winget-manifest.defaultLocale.$ManifestVersion.schema.json
+PackageIdentifier: $PackageIdentifier
+PackageVersion: "$Version"
+PackageLocale: $Locale
+Publisher: $Publisher
+PublisherUrl: https://github.com/automationjp
+PublisherSupportUrl: $RepoUrl/issues
+PackageName: HyperDU
+PackageUrl: $RepoUrl
+License: MIT
+LicenseUrl: $RepoUrl/blob/main/LICENSE
+ShortDescription: Fast cross-platform disk usage analyzer.
+Description: >-
+  HyperDU reports where disk space went. It uses each platform's bulk
+  enumeration API and a work-stealing scanner, and can read the NTFS MFT
+  directly when run elevated against a volume root.
+Moniker: hyperdu
+Tags:
+  - cli
+  - disk
+  - disk-usage
+  - du
+  - filesystem
+  - storage
+ManifestType: defaultLocale
+ManifestVersion: $ManifestVersion
+"@
+
+$files = [ordered]@{
+  "$PackageIdentifier.yaml"                = $versionYaml
+  "$PackageIdentifier.installer.yaml"      = $installerYaml
+  "$PackageIdentifier.locale.$Locale.yaml" = $localeYaml
+}
+
+foreach ($name in $files.Keys) {
+  $path = Join-Path $OutDir $name
+  # winget-pkgs requires UTF-8, and a BOM makes its validation fail.
+  [System.IO.File]::WriteAllText($path, $files[$name], (New-Object System.Text.UTF8Encoding($false)))
+  Write-Host "Wrote $path"
+}
+
+Write-Host ''
+Write-Host "Submit with:  wingetcreate submit --token <PAT> $OutDir"
+Write-Host "Or copy into: winget-pkgs/manifests/a/$Publisher/HyperDU/$Version/"


### PR DESCRIPTION
公開後のセットアップ手順を確認したところ、**実際に動くのは `cargo install` だけ**でした。3 つとも足場のままで、そのまま公開してもインストールできません。

## winget

出力が **pre-1.0 のプレビュー形式**で、現行の winget（ManifestVersion 1.12.0）では受け付けられません。

```yaml
Id: YourOrg.HyperDU      # 現行は PackageIdentifier
Version: ...             # 現行は PackageVersion
Name: HyperDU            # 現行は PackageName
Publisher: Your Org      # 置換されないまま
InstallerType: exe
```

必須の `PackageLocale` / `ShortDescription` / `ManifestType` / `ManifestVersion` もありませんでした。**3 ファイル構成**（version / installer / defaultLocale）で書き直しています。

### `InstallerType` を `portable` に変更

配布物は**素の実行ファイルでインストーラではない**ため、winget が `exe` に要求するサイレントインストールを満たせません。`portable` は単体実行ファイル向けの型で、winget が PATH にシムを置き、アンインストールも面倒を見ます。

### 識別子

`YourOrg.HyperDU` → **`automationjp.HyperDU`**。`release.yml` は `__URL__` と `__SHA256__` しか置換しないため、この 2 つは出力に残ったままでした。

## scoop

```powershell
bin = 'hyperdu.exe'   # 実際に生成されるのは hyperdu-cli.exe
```

**インストールできてもコマンドが通らない状態**でした。`[[bin]]` が無いため cargo はパッケージ名でバイナリを作ります。#45 で SKILL.md にあった同じ誤りを直したばかりです。

ダウンロード対象を **zip** にしました。scoop は展開してから `bin` を解決するので、リリース資産の名前が変わってもシム名が安定します。

## バージョンが `"0"` になっていた

**両スクリプトが共通で踏んでいた不具合**です。

```powershell
$Version = (Select-String ... | ForEach-Object { ... })[0]
```

`Select-String` の結果が 1 件のとき `ForEach-Object` は配列ではなく**文字列**を返します。その `[0]` は最初の**文字**なので、`"0.5.0-beta.1"` が **`"0"`** になります。`Cargo.toml` の行頭 `version` は 1 つしかないので、**常にこうなっていました**。

```
修正前: PackageVersion: "0"
修正後: PackageVersion: "0.5.0-beta.1"
```

`@()` で配列を強制しました。`release.yml` 側の同じ式も直しています。

## release.yml

`__URL__` の文字列置換をやめ、**URL と SHA256 を引数で渡す**方式にしました。置換対象のファイル名が変わるたびに壊れる作りでした。

winget には素の `.exe`、scoop には `.zip` と**別々の資産**を渡しています（理由は上記）。資産が見つからない場合は**例外**にしました。以前は `if ($asset)` で黙って飛ばしており、**マニフェストがプレースホルダのまま公開される**可能性がありました。

## 検証

両スクリプトを実際に実行して確認しました。

```
winget: YAML 3 ファイルが妥当、ManifestVersion 1.12.0
        PackageVersion = 0.5.0-beta.1
scoop : JSON が妥当、bin = hyperdu-cli.exe
        version = 0.5.0-beta.1
```

Rust コードの変更はありません。

## 残っている作業（この PR の範囲外）

**マニフェストを生成しても、自動では配布されません。**

- **winget**: [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) への PR が必要です。`wingetcreate submit` で自動化できますが、CI に GitHub トークンを置く判断が要ります
- **scoop**: バケットへの登録が必要です。今回は「マニフェスト生成の修正のみ」というご判断だったため、提出は行いません
- **Homebrew**: `HOMEBREW_TAP_TOKEN` / `HOMEBREW_TAP_REPO` が未設定のため、tap への PR はスキップされます

Refs #50
