### PR TITLE
fix: MFT比較のフォールバック誤判定を防止しスパース継続レコードを修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Test core and CLI
         run: cargo test -p hyperdu-core -p hyperdu-cli -- --nocapture
 
-  # The Windows enumeration backend and its tests are cfg(windows), so the Linux
-  # job compiles neither. Run them where they apply.
+  # Native enumeration and MFT I/O need Windows. A fresh, owned NTFS VHDX is
+  # populated and remounted read-only; parity must use MFT, never its fallback.
   test-windows:
     runs-on: windows-latest
     steps:
@@ -47,7 +47,7 @@ jobs:
           components: clippy
       - name: Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
-      - name: Test core and CLI
-        run: cargo test -p hyperdu-core -p hyperdu-cli -- --nocapture
+      - name: Test core and CLI on a fixed NTFS volume
+        run: .\scripts\test-ntfs-fixture.ps1
 
   # Note: artifact packaging is handled in release.yml on tags. CI only builds and tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,9 @@ HyperDiskUsage is a Rust workspace with four crates: `hyperdu-core/` hosts the s
 Distribution artifacts sit in `dist/`, while `packaging/`, `scripts/`, and `snap/` capture installer specs and automation. Keep generated output in `target/` out of version control.
 
 ## Build, Test, and Development Commands
-`cargo check --workspace` gives a fast compile sanity pass. Run `cargo fmt --check` to enforce formatting and `cargo clippy --workspace --all-targets --all-features` to lint. Clippy takes the MSRV from each crate's own `rust-version`, since `hyperdu-mcp` needs 1.88 for rmcp while the other three still build on 1.75.
-Use `cargo test --workspace --all-features` for the full suite. Manual checks include `cargo run -p hyperdu-cli -- --help` and `cargo run -p hyperdu-gui --release`. Package builds via `pwsh scripts/release.ps1 -Profile release` should remain idempotent and reproducible.
+`cargo check --workspace` gives a fast compile sanity pass. Run `cargo fmt --check` to enforce formatting and `cargo clippy --workspace --all-targets` to lint. Clippy takes the MSRV from each crate's own `rust-version`, since `hyperdu-mcp` needs 1.88 for rmcp while the other three still build on 1.75.
+Use `cargo test --workspace` for the default suite. Also test the parallel configuration with `cargo test --workspace --features hyperdu-core/rayon-par,hyperdu-core/rayon-inner,hyperdu-core/simd-prefetch`. The `profiling` dependency supports only one backend at a time, so `--all-features` is not a valid configuration: it enables both Tracy and Puffin and produces duplicate macro definitions. Check them separately with `cargo check --workspace --features hyperdu-core/prof-tracy` and `cargo check --workspace --features hyperdu-core/prof-puffin`; never report that as a successful `--all-features` run. See `docs/design/mft-parity-verification.md` for the reproduced baseline conflict.
+Manual checks include `cargo run -p hyperdu-cli -- --help` and `cargo run -p hyperdu-gui --release`. Package builds via `pwsh scripts/release.ps1 -Profile release` should remain idempotent and reproducible.
 
 ## Coding Style & Naming Conventions
 Follow Rust 2021 defaults with four-space indentation and a 100-character line limit from `rustfmt.toml`.

--- a/docs/design/mft-parity-verification.md
+++ b/docs/design/mft-parity-verification.md
@@ -1,0 +1,144 @@
+# MFT backend verification after #47
+
+## Scope
+
+This follow-up retains the product decisions recorded in #16 and #41: no resident
+Linux watcher is introduced and named DATA streams are not added to unnamed-file
+disk usage. It fixes two rejected NTFS layouts and makes backend comparisons
+prove which backend produced the result.
+
+The work starts at main `983bb01b8d6cae6d53eff47705438e2504477e68`.
+
+## Why the old green comparison was insufficient
+
+`mft_backend_applies` checks platform, root and elevation. It does not open the
+volume or prove that DATA resolution succeeded. `scan_directory` deliberately
+falls back to enumeration when the MFT backend declines a volume. Using that
+function for both sides of a parity test can compare two enumeration scans.
+Consequently, a low drift and a green test do not by themselves establish MFT
+parity. This qualification also applies to the 0.71% result previously cited in
+#41; it must not be treated as execution evidence for the MFT backend.
+
+A read-only probe of the hosted Windows runner reproduced a DATA rejection:
+
+- [First no-fallback probe](https://github.com/automationjp/HyperDiskUsage/actions/runs/34123710058).
+- [Attribute-reference trace](https://github.com/automationjp/HyperDiskUsage/actions/runs/34124093265).
+- [Accounting-invariant trace](https://github.com/automationjp/HyperDiskUsage/actions/runs/34124566961).
+- [Portable regression RED](https://github.com/automationjp/HyperDiskUsage/actions/runs/34124891163):
+  103 existing tests passed; the two new fixtures failed before the parser fix.
+
+The first rejected base record was 159135. Its named `$J` stream had a first
+extent covering VCN 0..609439 and a continuation covering 609440..871839. Both
+carried the sparse flag. The initial extent used the whole-stream physical-size
+header; the continuation did not repeat its local CompressionUnit value. The
+old equality check between these local interpretations rejected the stream.
+These record numbers are evidence from that runner, not hard-coded runtime rules.
+No file contents or paths from the runner are needed in the permanent fixture.
+
+## Parser contract
+
+The lowest-VCN-zero extent selects whole-stream size accounting. A continuation
+may omit the corresponding size header. Its local CompressionUnit does not
+select a second accounting mode. When the first extent requires counting sparse
+runs, the parser still reads and validates the continuation's run list; when the
+first extent supplies the physical total, that total is used once.
+
+An empty nonresident stream may have HighestVCN = -1. This sentinel is accepted
+only for LowestVCN = 0, zero allocated/data/initialized sizes, a zero derived
+physical size, and a terminated empty run list. Nonzero sizes, nonempty runs,
+and continuation extents cannot use the sentinel to hide allocation.
+
+Record sequence, owner, attribute instance and name, VCN continuity, matching
+flags, bounds and run-list validation remain in place. Invalid or unsupported
+DATA layouts still decline the MFT result rather than reporting a partial sum.
+
+Primary layout references:
+
+- [Microsoft ATTRIBUTE_RECORD_HEADER](https://learn.microsoft.com/en-us/windows/win32/devnotes/attribute-record-header)
+  documents the initial-extent scope of nonresident size fields.
+- [Linux NTFS attribute implementation](https://linux.googlesource.com/linux/kernel/git/torvalds/linux/+/1f57f68c4dd101e5e8ffc9ffa6428f45bcdd776a/fs/ntfs/attrib.c)
+  constructs an empty nonresident attribute with LowestVCN = 0, HighestVCN = -1,
+  zero size fields and a zero run-list terminator.
+
+## API and test contract
+
+`try_scan_directory_via_mft(root, options)` returns `Some(StatMap)` only from the
+MFT backend and applies the same child-to-parent rollup as `scan_directory`.
+It returns `None` instead of enumerating when that backend declines. `use_mft`
+must still be enabled. It does not add support for per-file MFT filters or link
+traversal.
+
+`scan_directory` calls this shared path and retains its existing enumeration
+fallback. Ordinary CLI and GUI callers need not change. The disabled path does
+not gain a second scan or a new per-file syscall.
+
+The parity test now obtains the MFT result first and requires `Some`. An explicit
+`HYPERDU_MFT_PARITY_ROOT` that cannot use MFT fails, rather than silently skipping.
+A normal unelevated local invocation may still skip with a reason. With
+`HYPERDU_MFT_DIAG=1`, DATA rejection is written to stderr even when no logger was
+initialized. A completed comparison prints `parity backend: mft (no fallback)`.
+
+## Controlled Windows integration fixture
+
+`scripts/test-ntfs-fixture.ps1` is restricted to an elevated GitHub Actions runner.
+It creates a new 256 MiB growable VHDX at a fresh GUID-named path in RUNNER_TEMP,
+selects an unused drive letter, and verifies that the resulting NTFS volume
+belongs to that image. It never selects or cleans a physical disk by number.
+After populating the fixture it detaches and reattaches that same image read-only,
+then runs the Core and CLI tests. The `finally` block restores environment values
+and detaches the owned image.
+
+The two backends must independently match these known unnamed-file totals:
+
+| Fixture subtree | Logical bytes | Physical bytes | Files |
+| --- | ---: | ---: | ---: |
+| `hyperdu-fixture/plain` | 8,388,608 | 8,388,608 | 128 |
+| `hyperdu-fixture/sparse` | 1,048,576 | 0 | 2 |
+| `hyperdu-fixture` | 9,437,184 | 8,388,608 | 130 |
+| Files directly below the volume root | 65,536 | 65,536 | 1 |
+
+An extra hardlink remains counted once, an 8 KiB named stream does not inflate
+the unnamed-file totals, and an empty directory must remain present. Sparse
+fixtures include both a fully unallocated 1 MiB stream and a zero-length stream.
+The test subtracts immediate child subtree totals to check root-direct files;
+it does not sum an already-rolled-up map.
+
+This verifies actual NTFS I/O and the production MFT path, rather than only a
+byte-array parser. It is not an exhaustive test of all NTFS layouts, WOF,
+compression, live races, permissions or large-volume performance. The existing
+live-volume 5% logical/file and 8% physical thresholds are not relaxed; the
+controlled subtrees additionally require exact byte and file counts.
+
+## Manual live-volume verification
+
+From an elevated PowerShell session in the repository:
+
+```powershell
+$env:HYPERDU_MFT_PARITY_ROOT = 'C:\'
+$env:HYPERDU_MFT_DIAG = '1'
+cargo test -p hyperdu-core --test mft_parity -- --nocapture
+```
+
+Do not set HYPERDU_MFT_PARITY_FIXTURE for a live volume. Prefer a quiescent test
+volume and record the commit, actual-backend marker, totals and diagnostics.
+Live-volume failures must be investigated rather than replaced with enumeration
+results or hidden by increasing the tolerance.
+
+## Feature configurations
+
+`cargo test --workspace --all-features` and the corresponding all-feature Clippy
+command fail in `profiling` 1.0.17 because Tracy and Puffin export the same macros.
+The dependency [explicitly supports one backend at a time](https://docs.rs/crate/profiling/1.0.17).
+This is not a successful all-feature test and is not changed by the MFT patch.
+The baseline check and separate configuration checks are recorded in the
+[verification workflow](https://github.com/automationjp/HyperDiskUsage/actions/runs/34126090430).
+Use the default workspace tests, the optional parallel-feature tests, and one
+profiler configuration per Cargo invocation; see AGENTS.md for exact commands.
+
+## Risk and rollback
+
+The changed parser now accepts the validated continuation and empty-stream
+layouts. It still falls back for unsupported layouts in ordinary scans. The
+strict API is additive; callers requiring compatibility keep `scan_directory`.
+The fixture changes only CI-created disposable storage. No release, publication,
+resident service, deletion tool or default MFT enablement is included.

--- a/hyperdu-core/src/lib.rs
+++ b/hyperdu-core/src/lib.rs
@@ -549,32 +549,35 @@ pub fn scan_roots(roots: &[PathBuf], opt: &Options) -> Vec<(PathBuf, Result<Stat
         .collect()
 }
 
-/// Whether [`scan_directory`] would read the `$MFT` for this root, rather than
-/// enumerating directories.
+/// Whether the MFT backend's platform, privilege and root preconditions apply.
 ///
-/// The scan itself falls back silently, which is the right behaviour but makes
-/// the choice invisible. A caller comparing the two backends needs to know
-/// which one ran -- otherwise "the totals match" can mean "both enumerated".
-///
-/// Checks the preconditions only; it does not open the volume.
+/// This does not open or parse the volume and is not proof that an MFT scan
+/// succeeded. Use [`try_scan_directory_via_mft`] when fallback must be excluded,
+/// for example when comparing the MFT and enumeration backends.
 pub fn mft_backend_applies(root: impl AsRef<Path>, opt: &Options) -> bool {
     platform::mft_backend_applies(root.as_ref(), opt)
 }
 
+/// Try the opt-in MFT backend without ever enumerating directories.
+///
+/// `Some` contains the MFT result, with the same child-to-parent rollup as
+/// [`scan_directory`]. `None` means the backend is disabled, unavailable for
+/// this platform/root/privilege level, or could not complete its volume parse.
+/// In particular, a successful eligibility check does not guarantee `Some`.
+///
+/// Set [`Options::use_mft`] to request this backend. This exposes the existing
+/// MFT path, not additional support for per-file filters or link traversal.
+/// Ordinary callers should use [`scan_directory`] to retain its safe fallback.
+pub fn try_scan_directory_via_mft(root: impl AsRef<Path>, opt: &Options) -> Option<StatMap> {
+    platform::scan_volume_via_mft(root.as_ref(), opt).map(rollup::rollup_child_to_parent)
+}
+
 pub fn scan_directory(root: impl AsRef<Path>, opt: &Options) -> Result<StatMap> {
     let root = root.as_ref();
-    // Reading the MFT answers the whole volume at once, so it replaces the walk
-    // rather than feeding it. Anything that makes it inapplicable returns None
-    // and the normal scan runs: a slower correct answer beats a fast partial
-    // one. Off unless `use_mft` is set.
-    if let Some(map) = platform::scan_volume_via_mft(root, opt) {
-        // Roll up here too. `to_stat_map` charges each file to its own
-        // directory, which is what the walking backends produce *before*
-        // `scan_directory_with` rolls them up -- returning it as-is handed
-        // callers a map with different semantics depending on which backend
-        // ran, so a directory's reported size was its own bytes under `--mft`
-        // and its whole subtree's everywhere else.
-        return Ok(rollup::rollup_child_to_parent(map));
+    // The explicit MFT API owns rollup for both callers. Failure here retains
+    // the ordinary scanner's fallback, but parity tests can require `Some`.
+    if let Some(map) = try_scan_directory_via_mft(root, opt) {
+        return Ok(map);
     }
     let scanner = Arc::new(crate::scanner::platform_scanner());
     scan_directory_with(root, opt, scanner)

--- a/hyperdu-core/src/platform/windows_impl/mft_reader.rs
+++ b/hyperdu-core/src/platform/windows_impl/mft_reader.rs
@@ -1525,4 +1525,78 @@ mod tests {
             assert!(!reader.is_complete());
         }
     }
+
+    #[test]
+    fn continuation_uses_the_initial_extents_allocation_mode() {
+        // The initial extent has the whole-stream allocation field at 0x40.
+        // A continuation omits that field and need not repeat CompressionUnit.
+        let (mut base, ext) = data_extension_fixture(true);
+        let h = parse_record_header(&base).unwrap();
+        let data = Attributes::new(&base, &h)
+            .find(|a| a.type_code == attr_type::DATA)
+            .unwrap();
+        let list = data.pos + data.total_length;
+        let used = h.used_size as usize;
+        base.copy_within(list..used, list + 8);
+        base[data.pos + 4..data.pos + 8].copy_from_slice(&80u32.to_le_bytes());
+        base[data.pos + 32..data.pos + 34].copy_from_slice(&72u16.to_le_bytes());
+        base[data.pos + 34..data.pos + 36].copy_from_slice(&4u16.to_le_bytes());
+        base[data.pos + 64..data.pos + 72].copy_from_slice(&(3 * CLUSTER as u64).to_le_bytes());
+        base[data.pos + 72..data.pos + 78].copy_from_slice(&[0x11, 1, 40, 0x01, 1, 0]);
+        set_used(&mut base, (used + 8) as u32);
+        let mut reader =
+            MftReader::open(volume(with_metadata_records(vec![base, ext], 5))).unwrap();
+        let entry = reader
+            .entry(16)
+            .expect("continuation must not invalidate the stream");
+        assert_eq!(entry.sizes.allocated_size, 3 * CLUSTER as u64);
+        assert_eq!(entry.sizes.real_size, 16384);
+        assert!(reader.is_complete());
+    }
+
+    #[test]
+    fn zero_length_nonresident_sparse_stream_is_valid() {
+        for with_named in [false, true] {
+            let mut rec = blank_record(1, 1);
+            let data = push_file_name(&mut rec, 64, ROOT_RECORD, "empty-sparse");
+            let mut end = push_nonresident_data(&mut rec, data, 0, 0);
+            rec[data + 12..data + 14].copy_from_slice(&0x8000u16.to_le_bytes());
+            rec[data + 24..data + 32].copy_from_slice(&u64::MAX.to_le_bytes());
+            rec[data + 32..data + 34].copy_from_slice(&64u16.to_le_bytes());
+            rec[data + 64..data + 72].fill(0);
+            if with_named {
+                end = named_data(&mut rec, end, "ads", 4096, 123);
+            }
+            set_used(&mut rec, end as u32);
+            let mut reader = MftReader::open(volume(with_metadata_records(vec![rec], 5))).unwrap();
+            let entry = reader
+                .entry(16)
+                .expect("empty runlist and VCN -1 describe an empty stream");
+            assert_eq!(entry.sizes.real_size, 0);
+            assert_eq!(entry.sizes.allocated_size, 0);
+            assert!(reader.is_complete());
+        }
+    }
+
+    #[test]
+    fn empty_vcn_marker_does_not_hide_allocations_or_continuations() {
+        for bad in 0..4 {
+            let mut rec = blank_record(1, 1);
+            let data = push_file_name(&mut rec, 64, ROOT_RECORD, "bad-empty");
+            let end = push_nonresident_data(&mut rec, data, 0, 0);
+            rec[data + 12..data + 14].copy_from_slice(&0x8000u16.to_le_bytes());
+            rec[data + 24..data + 32].copy_from_slice(&u64::MAX.to_le_bytes());
+            rec[data + 32..data + 34].copy_from_slice(&64u16.to_le_bytes());
+            match bad {
+                0 => rec[data + 40..data + 48].copy_from_slice(&4096u64.to_le_bytes()),
+                1 => rec[data + 48..data + 56].copy_from_slice(&1u64.to_le_bytes()),
+                2 => rec[data + 16..data + 24].copy_from_slice(&1u64.to_le_bytes()),
+                _ => rec[data + 64..data + 68].copy_from_slice(&[0x11, 1, 40, 0]),
+            }
+            set_used(&mut rec, end as u32);
+            let mut reader = MftReader::open(volume(with_metadata_records(vec![rec], 5))).unwrap();
+            assert!(reader.entry(16).is_none(), "invalid empty case {bad}");
+            assert!(!reader.is_complete());
+        }
+    }
 }

--- a/hyperdu-core/src/platform/windows_impl/mft_reader/streams.rs
+++ b/hyperdu-core/src/platform/windows_impl/mft_reader/streams.rs
@@ -128,17 +128,38 @@ fn extent(rec: &[u8], attr: &AttrHeader, cluster: u32) -> Option<Extent> {
     } else {
         None
     };
-    // CompressionUnit, not the COMPRESSED flag alone, decides whether the
-    // header carries physical compressed size (the #39 accounting contract).
+    // HighestVCN=-1 denotes an empty non-resident stream, not 2^64 clusters.
+    // Accept it only with zero sizes and an actually empty, terminated runlist.
+    let empty = attr.non_resident && high == u64::MAX;
+    if empty
+        && (low != 0
+            || u64_at(rec, attr.pos + 40)? != 0
+            || u64_at(rec, attr.pos + 48)? != 0
+            || u64_at(rec, attr.pos + 56)? != 0
+            || sizes?.allocated_size != 0
+            || !strict_runs(rec, attr)?.is_empty())
+    {
+        return None;
+    }
+    // CompressionUnit decides the initial extent's whole-stream accounting.
+    // Continuations can omit that header; their local value is not a second
+    // stream mode. Only the lowest-VCN-zero extent selects the final size.
     let sparse_uncompressed = attr.non_resident
         && attr.flags & attr_flags::SPARSE != 0
         && u16_at(rec, attr.pos + 34)? == 0;
-    let sparse_bytes = if sparse_uncompressed {
+    let sparse_bytes = if sparse_uncompressed
+        || (attr.non_resident && low > 0 && attr.flags & attr_flags::SPARSE != 0)
+    {
         let runs = strict_runs(rec, attr)?;
         let covered = runs
             .iter()
             .try_fold(0u64, |sum, run| sum.checked_add(run.length))?;
-        if covered != high.checked_sub(low)?.checked_add(1)? {
+        let expected = if empty {
+            0
+        } else {
+            high.checked_sub(low)?.checked_add(1)?
+        };
+        if covered != expected {
             return None;
         }
         runs.iter()
@@ -346,18 +367,19 @@ impl<S: VolumeSource> MftReader<S> {
             let mut end = 0u64;
             let mut sparse_bytes = 0u64;
             for (n, ext) in extents.iter().enumerate() {
-                if ext.low != end
-                    || ext.flags != flags
-                    || ext.non_resident != non_resident
-                    || ext.sparse_uncompressed != sparse
-                {
+                if ext.low != end || ext.flags != flags || ext.non_resident != non_resident {
                     return None;
                 }
                 if n > 0 && !non_resident {
                     return None;
                 }
-                // Plain single-extent headers can describe an empty stream.
-                if has_list || extents.len() > 1 || sparse {
+                // Empty streams have no VCN range and cannot have continuations.
+                if non_resident && ext.high == u64::MAX {
+                    if extents.len() != 1 {
+                        return None;
+                    }
+                    end = 0;
+                } else if has_list || extents.len() > 1 || sparse {
                     end = ext.high.checked_add(1)?;
                     if end <= ext.low {
                         return None;

--- a/hyperdu-core/src/platform/windows_impl/mod.rs
+++ b/hyperdu-core/src/platform/windows_impl/mod.rs
@@ -77,7 +77,10 @@ pub fn scan_volume_via_mft(root: &std::path::Path, opt: &crate::Options) -> Opti
     let diag_clusters = reader.mft_clusters();
     let entries = reader.entries();
     if !reader.is_complete() {
-        log::warn!("MFT DATA extents incomplete or inconsistent; using directory enumeration");
+        log::warn!("MFT DATA extents incomplete or inconsistent; declining MFT result");
+        if std::env::var_os("HYPERDU_MFT_DIAG").is_some() {
+            eprintln!("mft-diag: rejected: DATA extents incomplete or inconsistent; no MFT result");
+        }
         return None;
     }
     let record_count = reader.record_count();
@@ -187,13 +190,8 @@ pub fn scan_volume_via_mft(
     None
 }
 
-/// Whether the MFT backend would be used for this root. See
-/// [`crate::mft_backend_applies`].
-///
-/// Shares its preconditions with `scan_volume_via_mft` through `mft_drive`, so
-/// the two cannot disagree -- a caller told "the MFT path will be used" and
-/// then silently given enumeration would draw the wrong conclusion from a
-/// comparison of the two.
+/// Check only eligibility, not whether opening and parsing the volume succeeds.
+/// See [`crate::mft_backend_applies`] and [`crate::try_scan_directory_via_mft`].
 #[cfg(target_env = "msvc")]
 pub fn mft_backend_applies(root: &std::path::Path, opt: &crate::Options) -> bool {
     mft_drive(root, opt).is_some()

--- a/hyperdu-core/tests/mft_backend_contract.rs
+++ b/hyperdu-core/tests/mft_backend_contract.rs
@@ -1,0 +1,23 @@
+//! The explicit backend API must not turn an unavailable MFT into a successful walk.
+use hyperdu_core::{scan_directory, try_scan_directory_via_mft, Options};
+
+#[test]
+fn declining_mft_does_not_return_the_enumeration_result() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("file"), vec![1u8; 4096]).unwrap();
+    let opt = Options {
+        use_mft: true,
+        ..Options::default()
+    };
+    assert!(try_scan_directory_via_mft(dir.path(), &opt).is_none());
+    // The existing public scanner must still fall back for the same request.
+    let map = scan_directory(dir.path(), &opt).unwrap();
+    let total = map.get(dir.path()).unwrap();
+    assert_eq!((total.logical, total.files), (4096, 1));
+}
+
+#[test]
+fn disabled_mft_does_not_return_a_successful_empty_result() {
+    let root = if cfg!(windows) { r"C:\" } else { "/" };
+    assert!(try_scan_directory_via_mft(root, &Options::default()).is_none());
+}

--- a/hyperdu-core/tests/mft_parity.rs
+++ b/hyperdu-core/tests/mft_parity.rs
@@ -21,7 +21,7 @@
 
 use std::path::PathBuf;
 
-use hyperdu_core::{scan_directory, Options};
+use hyperdu_core::{scan_directory, try_scan_directory_via_mft, Options};
 
 /// Volume to compare on. A whole volume is required: the MFT backend declines
 /// anything else, which would make the test compare enumeration with itself.
@@ -39,9 +39,8 @@ fn parity_root() -> PathBuf {
 /// producing a 9x "discrepancy" that was entirely the summing. Every other
 /// test in this crate reads the root entry; so does this one now.
 fn totals(map: &hyperdu_core::StatMap, root: &std::path::Path) -> (u64, u64, u64) {
-    map.get(root)
-        .map(|s| (s.logical, s.physical, s.files))
-        .unwrap_or((0, 0, 0))
+    let total = map.get(root).expect("scan must contain the requested root");
+    (total.logical, total.physical, total.files)
 }
 
 /// This found two real bugs, and neither was the one it first appeared to.
@@ -71,10 +70,15 @@ fn the_mft_backend_agrees_with_directory_enumeration() {
         ..Options::default()
     };
 
-    // Distinguishing "the totals match because both used enumeration" from "the
-    // totals match because the two backends agree" is the whole point, so check
-    // the backend actually engages before comparing anything.
+    // Skip only an ordinary local invocation without the required privileges.
+    // CI explicitly provides a freshly created NTFS volume: ineligibility is
+    // then a failure, not a passing test that performed no comparison.
     if !hyperdu_core::mft_backend_applies(&root, &mft_opt) {
+        assert!(
+            std::env::var_os("HYPERDU_MFT_PARITY_ROOT").is_none(),
+            "the explicitly requested parity volume must be eligible for MFT: {}",
+            root.display()
+        );
         eprintln!(
             "skipped: the MFT backend does not apply to {}.\n\
              \x20        Run from an elevated shell against a volume root (C:\\),\n\
@@ -84,20 +88,22 @@ fn the_mft_backend_agrees_with_directory_enumeration() {
         return;
     }
 
+    // Eligibility is not proof of backend execution. Obtain MFT first so a
+    // declined parse fails immediately, without an expensive comparison of
+    // enumeration against another enumeration. No process-global env mutation.
+    let from_mft = try_scan_directory_via_mft(&root, &mft_opt)
+        .expect("MFT did not complete; enumeration fallback is not a parity result");
+    eprintln!("parity backend: mft (no fallback)");
     let walked_opt = Options {
         use_mft: false,
         ..Options::default()
     };
     let walked = scan_directory(&root, &walked_opt).expect("enumeration scan");
 
-    // A failure here needs to say *where* the records went. The first attempt
-    // at fixing an under-count was aimed at the wrong stage because the only
-    // number available was the final one.
-    //
-    // SAFETY: single-threaded test setup, before any scan starts.
-    unsafe { std::env::set_var("HYPERDU_MFT_DIAG", "1") };
-    let from_mft = scan_directory(&root, &mft_opt).expect("mft scan");
-    unsafe { std::env::remove_var("HYPERDU_MFT_DIAG") };
+    if std::env::var_os("HYPERDU_MFT_PARITY_FIXTURE").is_some() {
+        assert_fixture(&from_mft, &root);
+        assert_fixture(&walked, &root);
+    }
 
     let (wl, wp, wf) = totals(&walked, &root);
     let (ml, mp, mf) = totals(&from_mft, &root);
@@ -160,27 +166,14 @@ fn the_mft_backend_agrees_with_directory_enumeration() {
     eprintln!(
         "drift:       files={file_drift:.2}% logical={byte_drift:.2}% physical={phys_drift:.2}%"
     );
-    // Physical gets a looser bar than files and logical, and the reason is not
-    // that it matters less -- it is that the two sides genuinely measure
-    // different things at the margins:
-    //
-    //   * A file whose $DATA lives in an extension record reports no size from
-    //     its base record, and the $FILE_NAME copy is stale.
-    //   * A sparse file whose runs continue in an extension record is measured
-    //     only from the runs the base record holds.
-    //   * Named streams (WOF-compressed data among them) are not counted, which
-    //     matches what `du` does but not what the enumeration API reports.
-    //
-    // Measured residual on a real volume: 5.41%, the MFT under-reporting by
-    // 6.1 GB. Tracked in #39. The bar sits above that and far below the 33%
-    // this was before sparse runs were handled, so a regression to charging
-    // holes still fails here.
+    // Retain the historical live-volume tolerance. A controlled CI fixture
+    // must additionally meet exact known totals below; a low live drift is not
+    // sufficient evidence that the MFT path executed (Refs #41, #47).
     const PHYSICAL_BAR: f64 = 8.0;
     assert!(
         phys_drift < PHYSICAL_BAR,
         "physical totals differ by {phys_drift:.2}% (enumeration {wp}, mft {mp}), \
-         above the {PHYSICAL_BAR}% allowed for the known extension-record and \
-         named-stream gaps. Check the mft-diag breakdown above: if the sparse \
+         above the {PHYSICAL_BAR}% live-volume tolerance. Check the mft-diag breakdown above: if the sparse \
          category is back in the tens of gigabytes, `parse_data_sizes` is \
          charging holes again. See #39."
     );
@@ -223,5 +216,36 @@ fn use_mft_off_never_engages_the_backend() {
     assert!(
         !hyperdu_core::mft_backend_applies(parity_root(), &opt),
         "the backend must stay off unless asked for"
+    );
+}
+
+/// Contract for scripts/test-ntfs-fixture.ps1. Both backends must independently
+/// match known fixture totals, not merely agree on the same erroneous number.
+fn assert_fixture(map: &hyperdu_core::StatMap, root: &std::path::Path) {
+    let fixture = root.join("hyperdu-fixture");
+    assert_eq!(
+        totals(map, &fixture.join("plain")),
+        (128 * 65536, 128 * 65536, 128)
+    );
+    assert_eq!(totals(map, &fixture.join("sparse")), (1048576, 0, 2));
+    assert_eq!(
+        totals(map, &fixture),
+        (128 * 65536 + 1048576, 128 * 65536, 130)
+    );
+    assert!(map.contains_key(&fixture.join("empty")));
+    let total = totals(map, root);
+    let children = map
+        .iter()
+        .filter(|(path, _)| path.parent() == Some(root))
+        .fold((0, 0, 0), |(l, p, f), (_, s)| {
+            (l + s.logical, p + s.physical, f + s.files)
+        });
+    assert_eq!(
+        (
+            total.0 - children.0,
+            total.1 - children.1,
+            total.2 - children.2
+        ),
+        (65536, 65536, 1)
     );
 }

--- a/scripts/test-ntfs-fixture.ps1
+++ b/scripts/test-ntfs-fixture.ps1
@@ -1,0 +1,94 @@
+# CI-only integration harness. It creates and formats only its own new VHDX;
+# no physical disk number is selected and no existing disk is cleaned/formatted.
+# https://learn.microsoft.com/windows-server/administration/windows-commands/attach-vdisk
+[CmdletBinding()]
+param()
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+if ($env:GITHUB_ACTIONS -ne 'true' -or -not $env:RUNNER_TEMP) {
+    throw 'This harness is restricted to GitHub Actions. Use mft_parity directly for a live volume.'
+}
+$principal = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw 'The NTFS integration fixture requires an elevated runner.'
+}
+$owned = Join-Path $env:RUNNER_TEMP ('hyperdu-ntfs-' + [Guid]::NewGuid().ToString('N'))
+if ($owned -match '["\r\n]' -or (Test-Path -LiteralPath $owned)) { throw 'Unsafe fixture path.' }
+$null = New-Item -ItemType Directory -Path $owned
+$vhd = Join-Path $owned 'fixture.vhdx'
+$letter = @('Z','Y','X','W','V','U','T','S','R') | Where-Object {
+    -not (Get-PSDrive -Name $_ -ErrorAction SilentlyContinue) -and
+    -not (Test-Path -LiteralPath "${_}:\")
+} | Select-Object -First 1
+if (-not $letter) { throw 'No unused fixture drive letter.' }
+$root = "${letter}:\"
+$previous = @{}
+foreach ($key in @('HYPERDU_MFT_PARITY_ROOT','HYPERDU_MFT_PARITY_FIXTURE','HYPERDU_MFT_DIAG')) {
+    $previous[$key] = [Environment]::GetEnvironmentVariable($key, 'Process')
+}
+function Invoke-OwnedDiskPart([string[]]$Commands) {
+    $script = Join-Path $owned ([Guid]::NewGuid().ToString('N') + '.txt')
+    ($Commands + 'exit') | Set-Content -LiteralPath $script -Encoding ascii
+    & diskpart /s $script
+    if ($LASTEXITCODE -ne 0) { throw "DiskPart failed ($LASTEXITCODE)." }
+}
+function Assert-OwnedVolume {
+    $imageDisk = Get-DiskImage -ImagePath $vhd | Get-Disk
+    $partition = Get-Partition -DriveLetter $letter
+    $volume = Get-Volume -DriveLetter $letter
+    if ($partition.DiskNumber -ne $imageDisk.Number -or
+        $volume.FileSystem -ne 'NTFS' -or $volume.FileSystemLabel -ne 'HyperDUFixture') {
+        throw 'Drive letter does not belong to the newly created NTFS image.'
+    }
+}
+try {
+    Invoke-OwnedDiskPart @(
+        "create vdisk file=`"$vhd`" maximum=256 type=expandable",
+        'attach vdisk', 'create partition primary',
+        'format fs=ntfs quick label=HyperDUFixture', "assign letter=$letter"
+    )
+    Assert-OwnedVolume
+    $fixture = Join-Path $root 'hyperdu-fixture'
+    foreach ($dir in @('plain','sparse','empty')) {
+        $null = New-Item -ItemType Directory -Path (Join-Path $fixture $dir) -Force
+    }
+    $payload = [byte[]]::new(65536)
+    for ($i = 0; $i -lt $payload.Length; $i++) { $payload[$i] = [byte]($i % 251) }
+    for ($i = 0; $i -lt 128; $i++) {
+        [IO.File]::WriteAllBytes((Join-Path $fixture "plain\file-$i.bin"), $payload)
+    }
+    [IO.File]::WriteAllBytes((Join-Path $root 'root-file.bin'), $payload)
+    # An alternate stream is diagnostic data, not extra unnamed-file bytes.
+    [IO.File]::WriteAllBytes((Join-Path $fixture 'plain\file-0.bin:fixture-ads'), [byte[]]::new(8192))
+    & fsutil hardlink create (Join-Path $fixture 'plain\alias.bin') (Join-Path $fixture 'plain\file-0.bin')
+    if ($LASTEXITCODE -ne 0) { throw 'Could not create fixture hardlink.' }
+    foreach ($item in @(@('hole.bin',1048576), @('empty.bin',0))) {
+        $path = Join-Path $fixture ('sparse\' + $item[0])
+        [IO.File]::WriteAllBytes($path, [byte[]]::new(0))
+        & fsutil sparse setflag $path
+        if ($LASTEXITCODE -ne 0) { throw 'Could not mark fixture sparse.' }
+        $file = [IO.File]::Open($path, [IO.FileMode]::Open, [IO.FileAccess]::Write, [IO.FileShare]::None)
+        try { $file.SetLength([long]$item[1]); $file.Flush($true) } finally { $file.Dispose() }
+    }
+    # Flush NTFS metadata by detaching, then forbid mutations during comparison.
+    Invoke-OwnedDiskPart @("select vdisk file=`"$vhd`"", 'detach vdisk', 'attach vdisk readonly')
+    if (-not (Test-Path -LiteralPath $root)) {
+        Invoke-OwnedDiskPart @("select vdisk file=`"$vhd`"", 'select partition 1', "assign letter=$letter")
+    }
+    Assert-OwnedVolume
+    $env:HYPERDU_MFT_PARITY_ROOT = $root
+    $env:HYPERDU_MFT_PARITY_FIXTURE = '1'
+    $env:HYPERDU_MFT_DIAG = '1'
+    Write-Host "Testing actual MFT and enumeration on read-only fixture $root"
+    & cargo test -p hyperdu-core -p hyperdu-cli -- --nocapture
+    if ($LASTEXITCODE -ne 0) { throw "Core/CLI tests failed ($LASTEXITCODE)." }
+} finally {
+    foreach ($key in $previous.Keys) {
+        [Environment]::SetEnvironmentVariable($key, $previous[$key], 'Process')
+    }
+    if (Test-Path -LiteralPath $vhd) {
+        Invoke-OwnedDiskPart @("select vdisk file=`"$vhd`"", 'detach vdisk')
+    }
+    # This path is a new GUID-named directory owned by this invocation only.
+    Remove-Item -LiteralPath $owned -Recurse -Force
+}


### PR DESCRIPTION
## 概要

Refs #41, #47

PR #47はマージ済みだったため、最新main `983bb01`からの後続PRです。#16の常駐監視見送り、#41の名前付きストリームを本体容量へ加算しない方針は維持します。

**従来の容量比較テストには、MFT解析が失敗して通常列挙へ戻っても成功する経路がありました。** `mft_backend_applies()`は利用条件の判定であり、解析成功の証明ではありません。過去の0.71%という差だけでは、MFT経路を比較した証拠になりません。

## 修正内容

### 実際のMFT結果を要求するAPI・比較テスト

- `try_scan_directory_via_mft()`を追加。MFTの結果だけを`Some`で返し、代替走査は行いません。rollupは通常APIと共有します。
- 比較テストはこのAPIの成功を必須にし、明示指定したボリュームが利用できない場合も失敗させます。
- 通常の`scan_directory()`では従来の安全な列挙フォールバックを維持します。診断指定時のDATA拒否はstderrにも表示します。

### 実Windowsで再現した継続レコードの誤拒否を修正

- 先頭extentと継続extentが異なるCompressionUnit／ヘッダ形式を持つケースを、別ストリームのモードとして扱わないようにします。
- 全体の容量はLowestVCN=0の先頭から取得し、必要な場合のみ各extentの非ホール領域を合算します。全体サイズの二重加算はしません。
- 正常な空の非residentストリーム（HighestVCN=-1、サイズ0、空のrunlist）も扱います。不正なサイズや継続レコードを隠すsentinelは拒否します。
- 所有元、版、属性instance、名前、VCN連続性、flags、境界の検証は維持します。

### 固定NTFSボリュームによる恒久CI

- CI内で新規の256 MiB VHDXだけを作成し、所有先・NTFS・ドライブ対応を照合します。
- 固定データ投入後に読み取り専用で再マウントし、Core・CLIテストを実行、終了時に切り離します。既存物理ディスクの選択・初期化は行いません。
- MFTと通常列挙が、それぞれ独立に既知の論理容量・物理容量・件数と一致することを検証します。通常ファイル、ルート直下、ハードリンク、ADS除外、スパース、空ファイル、空ディレクトリを含みます。

## 最終HEADの検証結果

対象HEAD: `1f28542beb6bcf072d47640115978edb4cf16a93`

[標準PR CI: 34126691147](https://github.com/automationjp/HyperDiskUsage/actions/runs/34126691147)

| 検証 | 結果 |
|---|---|
| Linux fmt・Clippy | 成功 |
| Shellcheck・nightly import整列 | 成功 |
| Linux workspace release build | 成功 |
| Linux Core・CLIテスト | 成功 |
| Windows native Clippy | 成功 |
| Windows 固定NTFS上のCore・CLIテスト | 成功 |

**Linux・Windows両ジョブが最終HEADで完了し、成功しました。**

### 追加検証と再現証拠

- [実Windowsでの失敗再現](https://github.com/automationjp/HyperDiskUsage/actions/runs/34123710058)
- [継続extentの属性追跡](https://github.com/automationjp/HyperDiskUsage/actions/runs/34124566961)
- [修正前RED](https://github.com/automationjp/HyperDiskUsage/actions/runs/34124891163): 既存103件成功、新規2件が想定どおり失敗。
- [修正後Linux](https://github.com/automationjp/HyperDiskUsage/actions/runs/34125665920): `cargo test --workspace` **216件成功／失敗0件**。MFT純粋パーサ106件を含みます。
- [追加検証](https://github.com/automationjp/HyperDiskUsage/actions/runs/34126090430): 並列処理構成も **216件成功／失敗0件**。通常Clippy、TracyとPuffinの個別ビルド、固定NTFSのCore・CLIテスト、ライブC:の直接MFT読取probe、Windows Clippyが成功。

追加検証ソースは `8ba1c12401725c74a3909c996b641f8530dcafa0`。本PRは同じ本番コード・回帰テストを最新mainへの1コミットに整理し、一時probe・workbench・パッチ運搬ファイルを除去したものです。最終差分は10ファイルです。

### 計測値の区別

固定NTFSでは `parity backend: mft (no fallback)` を確認。意図的に投入した各fixtureの期待値は両バックエンドで完全一致しました。ボリューム全体の数値は以下です。

| 経路 | 論理bytes | 物理bytes | files | dirs |
|---|---:|---:|---:|---:|
| 通常列挙 | 9,502,732 | 8,454,160 | 132 | 6 |
| 実MFT | 9,502,732 | 8,454,156 | 132 | 6 |

**全体の物理量には4バイト差が残ります。** 小数2桁のログでは0.00%ですが、完全な0バイト差とは報告しません。既知のユーザーfixture部分とは分けて扱います。

ライブC:のprobeも、レコード範囲1,342,464枠（予約レコードを除く走査）を処理し、修正前に再現したDATA拒否なしで完了しました。これはMFT解析の検証であり、通常列挙とのライブ容量差の確定ではありません。

### 全機能ビルドについて

`--all-features`はTracy/Puffinを同時に有効化し、依存`profiling`で重複マクロ定義エラーになります。修正前mainでも再現しています。成功扱いにはしていません。依存ライブラリは同時に1バックエンドのみをサポートするため、個別構成を検証し、AGENTS.mdの実行コマンドを訂正しました。Cargo依存・機能構成の変更はありません。

## レビュー・リスク・切り戻し

- CodeRabbitの当該HEADレビューでは追加修正要求なし。Codex自動レビューは利用上限により実行されていません。
- 未対応・不整合なDATAでは通常走査へ戻る既存動作を維持します。MFTを既定で有効化する変更はありません。
- 固定NTFS上の正しさを、大規模ライブボリューム全般の容量差ゼロや性能改善の保証にはしません。既存のライブ比較許容値は緩めていません。
- Linux常駐監視、ADS/WOF一律加算、リリース公開、マージは行っていません。
- 問題時は通常走査（`--mft`なし）を使用できます。

詳細・根拠・手動再現方法: `docs/design/mft-parity-verification.md`。