### PR TITLE
ci: スクリプトのパス参照が解決することを lint で検査する

### DIFF
--- a/scripts/lint/paths.sh
+++ b/scripts/lint/paths.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Every script path mentioned anywhere in the tree must resolve.
+#
+# This exists because reorganising the helper scripts into subdirectories broke
+# CI on both platforms, and the ad-hoc check meant to catch it did not. That
+# check only looked for forward-slash literals, so two forms went past it: a
+# glob, which silently matches nothing once files move, and a backslash spelling
+# used by the PowerShell call sites. The backslash one only runs on a tagged
+# release, so a broken reference there could have survived until publish day.
+#
+# Deliberately depends on nothing but bash and git. Every other step in the lint
+# pipeline skips when its tool is missing, which is how the broken glob passed a
+# local run: shellcheck was not installed, so nothing evaluated it.
+#
+# A line that mentions a path in prose rather than calling it can opt out with
+# the marker `lint-paths:ignore`.
+
+set -uo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")"/../.. && pwd)"
+cd "$repo_root" || exit 1
+
+# Leading path components matter: matching only from the directory name onwards
+# turned the skill's own bundled script into a path that resolves nowhere and
+# reported a working reference as broken. lint-paths:ignore
+pattern='[A-Za-z0-9_./\\-]*scripts[\\/][A-Za-z0-9_.*/\\-]+\.(sh|ps1)'
+
+fail=0
+checked=0
+
+while IFS= read -r hit; do
+    file="${hit%%:*}"
+    rest="${hit#*:}"
+    content="${rest#*:}"
+
+    # Prose, not a call site.
+    case "$content" in *lint-paths:ignore*) continue ;; esac
+
+    while IFS= read -r ref; do
+        [ -n "$ref" ] || continue
+
+        # Backslashes are how the PowerShell call sites spell the same path; a
+        # leading ./ or .\ carries no meaning here.
+        norm="${ref//\\//}"
+        norm="${norm#./}"
+
+        # Call sites in the shell scripts write "$root_dir/scripts/...", and the
+        # capture keeps the variable name because the `$` is not part of a path.
+        # Trying the tail from the last directory segment covers that without
+        # having to know which variables hold the repo root.
+        tail_ref="scripts/${norm##*scripts/}"
+
+        # A reference resolves against the repo root, against the directory of
+        # the file that mentions it, or -- for the variable case above -- from
+        # the last path segment onwards.
+        ok=0
+        for cand in "$norm" "$(dirname -- "$file")/$norm" "$tail_ref"; do
+            case "$cand" in
+                *'*'*)
+                    # A glob matching nothing is the failure that broke CI, so
+                    # expansion has to be checked, not just the spelling.
+                    compgen -G "$cand" >/dev/null 2>&1 && ok=1
+                    ;;
+                *)
+                    [ -e "$cand" ] && ok=1
+                    ;;
+            esac
+            [ "$ok" -eq 1 ] && break
+        done
+
+        checked=$((checked + 1))
+        if [ "$ok" -eq 0 ]; then
+            echo "  BROKEN  $ref" >&2
+            echo "          referenced by $file" >&2
+            fail=1
+        fi
+    done < <(printf '%s\n' "$content" | grep -oE "$pattern" | sort -u)
+done < <(git grep -nIE "$pattern" -- ':!target' 2>/dev/null)
+
+if [ "$fail" -ne 0 ]; then
+    echo "script path references do not resolve" >&2
+    exit 1
+fi
+
+echo "(info) $checked script path references resolve"

--- a/scripts/lint/run.sh
+++ b/scripts/lint/run.sh
@@ -110,4 +110,10 @@ else
   echo "(info) cargo-deny not found; skipping dependency audit"
 fi
 
+# Unconditional on purpose. Every other step above skips when its tool is
+# missing, and that is how a broken shellcheck glob passed a local lint run and
+# then failed CI: shellcheck was not installed, so nothing evaluated it.
+echo "==> script path references"
+bash scripts/lint/paths.sh
+
 echo "OK"


### PR DESCRIPTION
`scripts/` をサブディレクトリに分けたとき、**CI を両プラットフォームで落としました**。そのとき私がやった検証は一度きりの手作業で、しかも穴がありました。

## 何を見落としたか

スラッシュのリテラルパスしか見ておらず、2 つの形式を素通りしていました。

```
shellcheck -S error -x scripts/*.sh    グロブ。移動後は 0 件にマッチする
.\scripts\test-ntfs-fixture.ps1        バックスラッシュ
```

**後者は `release.yml` にもあり、あちらはタグを打つまで CI で動きません。** 公開当日まで壊れたまま残りうる形でした。

同じ盲点が再発しないよう、**検査を恒久化**します。

## 実装

`git grep` で追跡ファイル中のスクリプト参照を集め、実在を確認します。

**外部ツールに依存させていません。** 他の lint ステップはツールが無ければスキップする作りで、それこそが今回の見逃しを許しました。ローカルに shellcheck が入っていなかったため、**壊れたグロブが評価されないまま lint が `OK` を返していました**。

## 書きながら検査自体が教えてくれたこと

参照の形式は想定より多くありました。

| 形式 | 対応 |
|---|---|
| `plugin/skills/<skill>/scripts/setup-hyperdu.sh` | **先頭のパスまで拾わないと、動いている参照を壊れていると誤報**する |
| `"$root_dir/scripts/dev/build_print.sh"` | `$` はパスの一部ではないので変数名が残る。**最後のディレクトリセグメント以降**で解決すれば、どの変数がルートを持つか知らずに済む |

散文でパスに言及する行は `lint-paths:ignore` で除外できます。

## 検証

**通ることと落ちることの両方**を確かめました。失敗しない検査は無意味だからです。

正しいツリーで **91 件**の参照がすべて解決することを確認したうえで、CI を落とした 2 形式と旧フラットパス 2 種を故意に混ぜました。

| 混入した参照 | 結果 |
|---|---|
| `.\scripts\test-ntfs-fixture.ps1` | **検出** |
| `shellcheck -x scripts/*.sh` | **検出** |
| `bash scripts/lint_all.sh` | **検出** |
| `pwsh scripts/package_winget.ps1` | **検出** |

- `bash scripts/lint/run.sh`: 全ステップ完走、`(info) 91 script path references resolve` → `OK`
- `cargo test --workspace`: 220 件通過 / 16 スイート
- Rust コードの変更はありません

## あわせて

この作業と対で、**Issue #41 に残っていた私の誤った報告を訂正**しました（[コメント](https://github.com/automationjp/HyperDiskUsage/issues/41#issuecomment-5573494332)）。物理差 0.71% を「解決の根拠」として提示しましたが、当時のテストは MFT 解析が失敗すると黙って列挙にフォールバックするため、**MFT 経路で比較した証拠になっていませんでした**。診断行が出ていることを経路実行の証明として扱ったのが誤りです。PR #52 でその穴は塞がれ、固定 NTFS 上で物理・論理とも 0.00% を確認できています。
