### PR TITLE
feat: コマンド名を hyperdu にする（クレート名は hyperdu-cli のまま）

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@
 
 ```bash
 # CLI
-cargo install hyperdu-cli --version 0.5.0-beta.1
+cargo install hyperdu-cli --version 0.5.0-beta.2
 
 # エージェント向け MCP サーバ
 cargo install hyperdu-mcp --version 0.5.0-beta.1
@@ -81,7 +81,7 @@ cargo install hyperdu-gui --version 0.5.0-beta.1
 
 ベータ版のため、`--version` の明示が要ります（プレリリースは既定で選ばれません）。
 
-**インストールされるコマンド名は `hyperdu-cli` です。** 短い `hyperdu` は deb / rpm パッケージ側でのリネームでのみ存在します。
+**クレート名は `hyperdu-cli` ですが、入るコマンドは `hyperdu` です。** `ripgrep` が `rg` を入れるのと同じ形で、deb / rpm パッケージのコマンド名とも揃います。
 
 ### Windows のパッケージマネージャ
 
@@ -187,12 +187,12 @@ plugin/skills/disk-space-triage/scripts/setup-hyperdu.sh --register # 登録ま�
 
 ```bash
 # 従来の du を HyperDU に置き換え
-alias du='hyperdu-cli --compat gnu'
+alias du='hyperdu --compat gnu'
 
 # du と同じオプションがそのまま使える
-hyperdu-cli --compat gnu -sh /var/log
-hyperdu-cli --compat gnu -ak /home --max-depth=2
-hyperdu-cli --compat gnu -b --time /usr/share
+hyperdu --compat gnu -sh /var/log
+hyperdu --compat gnu -ak /home --max-depth=2
+hyperdu --compat gnu -b --time /usr/share
 
 # du 互換の出力形式で高速動作を目指しています
 ```
@@ -201,26 +201,26 @@ hyperdu-cli --compat gnu -b --time /usr/share
 
 ```bash
 # カレントディレクトリをスキャン（デフォルトは高速モード）
-hyperdu-cli .
+hyperdu .
 
 # ターボモードで最速スキャン
-hyperdu-cli --perf turbo /large/directory
+hyperdu --perf turbo /large/directory
 
 # 進捗表示とライブチューニング付き
-hyperdu-cli /large/directory --progress --tune-log
+hyperdu /large/directory --progress --tune-log
 
 # 特定のディレクトリを除外して高速化
-hyperdu-cli . --exclude ".git,node_modules,target,build"
+hyperdu . --exclude ".git,node_modules,target,build"
 
 # CSV/JSON形式で出力
-hyperdu-cli . --csv output.csv --json output.json
+hyperdu . --csv output.csv --json output.json
 ```
 
 ### コマンドラインオプション
 
 ```
 USAGE:
-    hyperdu-cli [OPTIONS] <ROOT>
+    hyperdu [OPTIONS] <ROOT>
 
 ARGS:
     <ROOT>    スキャンするディレクトリパス
@@ -252,25 +252,25 @@ OPTIONS:
 
 ```bash
 # 1GB以上のファイルのみをカウント
-hyperdu-cli / --min-file-size 1073741824
+hyperdu / --min-file-size 1073741824
 
 # 3階層までの深さでスキャン
-hyperdu-cli . --max-depth 3
+hyperdu . --max-depth 3
 
 # 複数の除外パターンを指定
-hyperdu-cli ~/projects --exclude ".git,node_modules,target,build,dist"
+hyperdu ~/projects --exclude ".git,node_modules,target,build,dist"
 
 # 物理サイズの計算をスキップして高速化（論理サイズのみ）
-hyperdu-cli / --logical-only
+hyperdu / --logical-only
 
 # 推定サイズモードで高速スキャン（精度とトレードオフ）
-hyperdu-cli / --approximate
+hyperdu / --approximate
 
 # ライブチューニングのログを表示しながらスキャン
-hyperdu-cli /large/directory --progress --tune-log
+hyperdu /large/directory --progress --tune-log
 
 # 最適なパラメータを2秒間で測定
-hyperdu-cli /large/directory --tune-only --tune-secs 2
+hyperdu /large/directory --tune-only --tune-secs 2
 ```
 
 ## 🖼️ GUI版
@@ -330,7 +330,7 @@ warm は 5 回の最小値、cold は 3 回の burn-in 後に両ツールを交�
 du -sh /path/to/directory
 
 # HyperDU で完全互換動作
-hyperdu-cli --compat gnu -sh /path/to/directory
+hyperdu --compat gnu -sh /path/to/directory
 
 # du 互換の出力形式を目指しています
 ```
@@ -464,7 +464,7 @@ WITH_RAYON=1 scripts/bench/run.sh --root /path/to/dir
 
 ### ランタイムチューニング（任意・上級者）
 
-- `hyperdu-cli … --tune` でアダプティブチューナを有効化（dir_yield/実行スレッド数を動的調整）
+- `hyperdu … --tune` でアダプティブチューナを有効化（dir_yield/実行スレッド数を動的調整）
 - スレッドは `active_threads` を動的に制御（[1, threads] 範囲）
   - I/O待ちやSQE失敗が多い→縮退
   - throughput改善が続く→段階的に増加
@@ -518,8 +518,8 @@ WITH_RAYON=1 scripts/bench/run.sh --root /path/to/dir
 
 ```sh
 mkdir -p "$HOME/.cache/hyperdu"
-hyperdu-cli index refresh /srv/data --database "$HOME/.cache/hyperdu/data.idx"
-hyperdu-cli index show /srv/data --database "$HOME/.cache/hyperdu/data.idx"
+hyperdu index refresh /srv/data --database "$HOME/.cache/hyperdu/data.idx"
+hyperdu index show /srv/data --database "$HOME/.cache/hyperdu/data.idx"
 ```
 
 `refresh` runs the existing physical-size scanner and atomically replaces a directory-level

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -111,7 +111,7 @@ Ubuntu 26.04 の `du` は **GNU coreutils ではなく uutils coreutils 0.8.0**�
 
 ```bash
 # Linux: 付属のスクリプトが公平性の条件を強制します
-scripts/bench/vs_du.sh --bin target/release/hyperdu-cli --runs 5 /usr /var
+scripts/bench/vs_du.sh --bin target/release/hyperdu --runs 5 /usr /var
 ```
 
 このスクリプトは、バイナリが古くないか、両ツールの走査対象が一致しているか、cold 計測で最小値を使っていないかを機械的に検査します。**いずれも過去に一度は破った条件**なので、文書ではなくコードで守らせています。

--- a/hyperdu-cli/Cargo.toml
+++ b/hyperdu-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hyperdu-cli"
-version = "0.5.0-beta.1"
+version = "0.5.0-beta.2"
 edition = "2021"
 license = "MIT"
 description = "HyperDU CLI - ultra-fast disk usage analyzer"
@@ -10,6 +10,15 @@ homepage = "https://github.com/automationjp/HyperDiskUsage#readme"
 readme = "README.md"
 keywords = ["disk-usage", "du", "filesystem", "cli", "performance"]
 categories = ["command-line-utilities", "filesystem"]
+
+# The command is `hyperdu`, not `hyperdu-cli`. Without this, cargo names the
+# binary after the package, and `cargo install hyperdu-cli` left users with a
+# command nobody expects -- the deb and rpm packages already renamed it on the
+# way in, so the two install paths disagreed. A crate name that differs from its
+# command is ordinary; ripgrep installs `rg`.
+[[bin]]
+name = "hyperdu"
+path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
@@ -76,7 +85,7 @@ group = "Applications/System"
 auto-req = true
 requires = []
 assets = [
-  { source = "../target/release/hyperdu-cli", dest = "/usr/bin/hyperdu", mode = "755" },
+  { source = "../target/release/hyperdu", dest = "/usr/bin/hyperdu", mode = "755" },
   { source = "../README.md", dest = "/usr/share/doc/hyperdu/README.md", mode = "644" },
   { source = "../LICENSE", dest = "/usr/share/doc/hyperdu/LICENSE", mode = "644" },
   { source = "../packaging/man/hyperdu.1", dest = "/usr/share/man/man1/hyperdu.1", mode = "644" },

--- a/hyperdu-cli/README.md
+++ b/hyperdu-cli/README.md
@@ -18,18 +18,19 @@ the results that are less flattering, is in
 ## Install
 
 ```bash
-cargo install hyperdu-cli --version 0.5.0-beta.1
+cargo install hyperdu-cli --version 0.5.0-beta.2
 ```
 
-The binary is named `hyperdu-cli`. The shorter `hyperdu` exists only in the deb
-and rpm packages, which rename it on install.
+The crate is `hyperdu-cli`; the command it installs is `hyperdu`. Same shape as
+ripgrep installing `rg`, and it matches what the deb and rpm packages have
+always called it.
 
 ## Use
 
 ```bash
-hyperdu-cli /path --top 20            # largest directories
-hyperdu-cli /path --json out.json     # structured output
-hyperdu-cli --compat gnu -sh /var/log # drop-in for du
+hyperdu /path --top 20            # largest directories
+hyperdu /path --json out.json     # structured output
+hyperdu --compat gnu -sh /var/log # drop-in for du
 ```
 
 Windows reads the NTFS `$MFT` directly when run elevated against a volume root,

--- a/hyperdu-cli/src/tuning.rs
+++ b/hyperdu-cli/src/tuning.rs
@@ -242,7 +242,7 @@ pub(crate) fn run_probe(args: &Args, opt: &Options) -> Result<()> {
         .ok()
         .and_then(|p| p.file_name().map(|name| name.to_string_lossy().to_string()))
         .map(|name| format!("./{name}"))
-        .unwrap_or_else(|| "./hyperdu-cli".to_string());
+        .unwrap_or_else(|| "./hyperdu".to_string());
 
     let mut pieces = Vec::with_capacity(1 + recommended_args.len() + filtered_args.len());
     pieces.push(shell_quote(&exe_display));

--- a/hyperdu-cli/tests/du_golden.rs
+++ b/hyperdu-cli/tests/du_golden.rs
@@ -1,15 +1,15 @@
 use std::process::Command;
 
-fn bin_path() -> String {
-    // Cargo sets CARGO_BIN_EXE_<name> for integration tests
-    if let Ok(p) = std::env::var("CARGO_BIN_EXE_hyperdu-cli") {
-        return p;
-    }
-    if let Ok(p) = std::env::var("CARGO_BIN_EXE_hyperdu_cli") {
-        return p;
-    }
-    let target = std::env::var("CARGO_TARGET_DIR").unwrap_or_else(|_| "target".into());
-    format!("{target}/debug/hyperdu-cli")
+/// The binary under test.
+///
+/// `env!`, not `std::env::var`: cargo sets `CARGO_BIN_EXE_<name>` at compile
+/// time for integration tests, so a wrong name is a build failure rather than a
+/// runtime miss. The previous version guessed at three paths and returned early
+/// when none of them existed, which meant renaming the binary made this test
+/// pass without ever starting the CLI. A test that skips itself when its
+/// subject is missing reports the same "ok" as one that ran.
+fn bin_path() -> &'static str {
+    env!("CARGO_BIN_EXE_hyperdu")
 }
 
 /// GNU du 互換出力: `-b`（= --apparent-size --block-size=1）でディレクトリ行のみ、
@@ -22,12 +22,7 @@ fn du_tab_output_lists_directories_only() {
     std::fs::write(root.join("b.txt"), vec![0u8; 1024]).unwrap();
     std::fs::write(root.join("a.txt"), vec![0u8; 2048]).unwrap();
 
-    let exe = bin_path();
-    if std::fs::metadata(&exe).is_err() {
-        eprintln!("skip: test binary not found at {exe}");
-        return;
-    }
-    let out = Command::new(exe)
+    let out = Command::new(bin_path())
         .arg(&root)
         .arg("--compat")
         .arg("gnu")

--- a/hyperdu-cli/tests/index_commands.rs
+++ b/hyperdu-cli/tests/index_commands.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 fn run(action: &str, root: &Path, db: &Path) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_hyperdu-cli"))
+    Command::new(env!("CARGO_BIN_EXE_hyperdu"))
         .args(["index", action])
         .arg(root)
         .arg("--database")
@@ -70,7 +70,7 @@ fn regular_scan_flags_are_not_silently_accepted_by_snapshot_commands() {
     let root = temp.path().join("root");
     let db = temp.path().join("index.bin");
     fs::create_dir(&root).unwrap();
-    let result = Command::new(env!("CARGO_BIN_EXE_hyperdu-cli"))
+    let result = Command::new(env!("CARGO_BIN_EXE_hyperdu"))
         .args(["--apparent-size", "index", "refresh"])
         .arg(&root)
         .arg("--database")
@@ -86,7 +86,7 @@ fn a_directory_named_index_can_still_be_scanned() {
     let temp = tempfile::tempdir().unwrap();
     fs::create_dir(temp.path().join("index")).unwrap();
     for args in [vec!["./index"], vec!["--", "index"]] {
-        let result = Command::new(env!("CARGO_BIN_EXE_hyperdu-cli"))
+        let result = Command::new(env!("CARGO_BIN_EXE_hyperdu"))
             .current_dir(temp.path())
             .args(args)
             .output()

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -13,7 +13,7 @@ which of that can be deleted without losing anything.
 | `skills/disk-space-triage/scripts/` | — | Setup for both binaries and the MCP server |
 
 The three surfaces are independent on purpose. The MCP server runs without the
-plugin, and the skill drives `hyperdu-cli` rather than the server, so **you can
+plugin, and the skill drives `hyperdu` rather than the server, so **you can
 adopt any one of them without the other two**.
 
 ## Setup
@@ -50,8 +50,8 @@ cargo install --git https://github.com/automationjp/HyperDiskUsage hyperdu-cli
 cargo install --git https://github.com/automationjp/HyperDiskUsage hyperdu-mcp
 ```
 
-The binary is `hyperdu-cli`, not `hyperdu`. The shorter name exists only in the
-deb and rpm packages, which rename it on install.
+The crate is `hyperdu-cli`; the command it installs is `hyperdu`. Same shape as
+ripgrep installing `rg`, and it matches the deb and rpm packages.
 
 Then register the MCP server with your client:
 
@@ -84,7 +84,7 @@ wrong report can be corrected, a wrong `rm -rf` cannot.
 ## Using only the skill
 
 Copy `skills/disk-space-triage/` anywhere your agent looks for skills. It needs
-`hyperdu-cli` and nothing else from this directory — not the MCP server, not the
+`hyperdu` and nothing else from this directory — not the MCP server, not the
 plugin manifest.
 
 ## Using only the MCP server

--- a/plugin/skills/disk-space-triage/SKILL.md
+++ b/plugin/skills/disk-space-triage/SKILL.md
@@ -2,7 +2,7 @@
 name: disk-space-triage
 description: Find out why a disk is full and what can safely be freed, using the HyperDU scanner. Use when a drive is out of space, a build fails with "no space left on device", or the user asks what is using their disk, which directories are largest, or what is safe to delete. Covers per-volume free space, largest-directory scans, and separating regenerable build output (Cargo target, node_modules, virtualenvs) from data that cannot be rebuilt.
 license: MIT
-compatibility: Requires the hyperdu-cli binary. Run scripts/setup-hyperdu.sh (or setup-hyperdu.ps1 on Windows) to install it; that needs a Rust toolchain, because HyperDU has no prebuilt release. Works on Windows, Linux, and macOS.
+compatibility: Requires the hyperdu binary. Run scripts/setup-hyperdu.sh (or setup-hyperdu.ps1 on Windows) to install it; that needs a Rust toolchain, because HyperDU has no prebuilt release. Works on Windows, Linux, and macOS.
 metadata:
   project: HyperDiskUsage
   repository: https://github.com/automationjp/HyperDiskUsage
@@ -13,7 +13,7 @@ metadata:
 Answer "why is the disk full and what can I delete" in a fixed order. Skipping
 a step is what produces confident wrong answers.
 
-This skill drives the `hyperdu-cli` command. It does not need the MCP server —
+This skill drives the `hyperdu` command. It does not need the MCP server —
 if that server is available, its `list_volumes`, `scan_path`, and
 `find_reclaimable` tools do the same work with typed arguments and structured
 results, and you should prefer them. This file is the fallback that works with
@@ -21,7 +21,8 @@ nothing but a shell.
 
 ## Setup
 
-The binary is called `hyperdu-cli`. If it is not on PATH, install it before
+The command is `hyperdu` (from the `hyperdu-cli` crate). If it is not on PATH,
+install it before
 doing anything else:
 
 ```bash
@@ -34,7 +35,7 @@ On Windows:
 .\scripts\setup-hyperdu.ps1
 ```
 
-The script installs `hyperdu-cli` and the `hyperdu-mcp` server, then prints the
+The script installs `hyperdu` and the `hyperdu-mcp` server, then prints the
 command to register the MCP server with Claude Code or Codex. It only performs
 that registration when passed `--register`, because rewriting an agent's
 configuration should be something the user asked for.
@@ -67,7 +68,7 @@ now, while one at 85% does not.
 ## Step 2 — What is large on it?
 
 ```bash
-hyperdu-cli /path/to/volume --top 20
+hyperdu /path/to/volume --top 20
 ```
 
 Read the output as a tree: HyperDU rolls sizes up, so a parent's size includes
@@ -89,7 +90,7 @@ will change.
 Scanning a full 930 GB disk with 4 million files takes roughly 47 seconds. Use
 `--max-depth` if you need an answer sooner.
 
-Check `hyperdu-cli --help` before inventing a flag. Guessing at one costs a full
+Check `hyperdu --help` before inventing a flag. Guessing at one costs a full
 scan to discover it does not exist.
 
 ## Step 3 — Drill into the largest subtree

--- a/plugin/skills/disk-space-triage/scripts/setup-hyperdu.ps1
+++ b/plugin/skills/disk-space-triage/scripts/setup-hyperdu.ps1
@@ -36,9 +36,9 @@ param(
 $ErrorActionPreference = 'Stop'
 
 $RepoUrl = 'https://github.com/automationjp/HyperDiskUsage'
-# The binary is `hyperdu-cli`, not `hyperdu`: the crate declares no [[bin]], so
-# cargo names it after the package. Only the deb/rpm packaging renames it.
-$CliBin = 'hyperdu-cli'
+# The crate is `hyperdu-cli`; the command it installs is `hyperdu`, declared
+# by a [[bin]] section. That matches what the deb and rpm packages install.
+$CliBin = 'hyperdu'
 $McpBin = 'hyperdu-mcp'
 $McpName = 'hyperdu'
 

--- a/plugin/skills/disk-space-triage/scripts/setup-hyperdu.sh
+++ b/plugin/skills/disk-space-triage/scripts/setup-hyperdu.sh
@@ -17,9 +17,9 @@
 set -eu
 
 REPO_URL="https://github.com/automationjp/HyperDiskUsage"
-# The binary is `hyperdu-cli`, not `hyperdu`: the crate declares no [[bin]], so
-# cargo names it after the package. Only the deb/rpm packaging renames it.
-CLI_BIN="hyperdu-cli"
+# The crate is `hyperdu-cli`; the command it installs is `hyperdu`, declared
+# by a [[bin]] section. That matches what the deb and rpm packages install.
+CLI_BIN="hyperdu"
 MCP_BIN="hyperdu-mcp"
 MCP_NAME="hyperdu"
 

--- a/scripts/bench/run.sh
+++ b/scripts/bench/run.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # Options:
 #   --root PATH   Root directory to scan (default: '.')
 #   --runs N      Iterations per case (default: env RUNS or 3)
-#   --bin PATH    Path to hyperdu-cli binary (default: find in PATH)
+#   --bin PATH    Path to hyperdu binary (default: find in PATH)
 #   -h, --help    Show this help
 #
 # Notes:
@@ -66,10 +66,10 @@ bench_one() {
 }
 
 if [[ -z "$BIN" ]]; then
-  BIN=$(command -v hyperdu-cli || true)
+  BIN=$(command -v hyperdu || true)
 fi
 if [[ -z "$BIN" ]]; then
-  echo "error: hyperdu-cli not found in PATH; build first"
+  echo "error: hyperdu not found in PATH; build first"
   exit 1
 fi
 
@@ -79,7 +79,7 @@ if [[ "$WITH_RAYON" == "1" ]]; then
   echo "==> building rayon-par variant"
   if cargo build -p hyperdu-cli --release --features rayon-par \
       --target-dir target/bench-rayon >/dev/null; then
-    bench_one "turbo+rayon-par" target/bench-rayon/release/hyperdu-cli "$ROOT" --perf turbo
+    bench_one "turbo+rayon-par" target/bench-rayon/release/hyperdu "$ROOT" --perf turbo
   else
     echo "  (skipped: rayon-par variant failed to build)" >&2
   fi

--- a/scripts/bench/vs_du.sh
+++ b/scripts/bench/vs_du.sh
@@ -7,7 +7,7 @@ set -uo pipefail
 #   scripts/bench/vs_du.sh [--bin PATH] [--runs N] [--cold] [--allow-stale] TREE [TREE...]
 #
 # Options:
-#   --bin PATH      hyperdu-cli binary (default: target/release/hyperdu-cli)
+#   --bin PATH      hyperdu binary (default: target/release/hyperdu)
 #   --runs N        Warm iterations per case (default: 5)
 #   --cold          Also measure with a cold page cache. Needs root, since it
 #                   writes to /proc/sys/vm/drop_caches between runs.
@@ -41,7 +41,7 @@ set -uo pipefail
 
 usage() { awk 'NR<=41 && /^#( |$)/ { sub(/^# ?/, ""); print }' "$0"; }
 
-BIN="target/release/hyperdu-cli"
+BIN="target/release/hyperdu"
 RUNS=5
 COLD=0
 ALLOW_STALE=0

--- a/scripts/package/scoop.ps1
+++ b/scripts/package/scoop.ps1
@@ -3,12 +3,11 @@
     Generate a Scoop manifest for the HyperDU CLI.
 
 .DESCRIPTION
-    Two things in the previous version made the resulting manifest unusable:
+    Two things in an earlier version made the resulting manifest unusable:
 
-      * `bin` was `hyperdu.exe`. Cargo names the binary after the package, so
-        what ships is `hyperdu-cli.exe`; the short name exists only inside the
-        deb and rpm packages, which rename it on install. Scoop would have
-        installed the package and left no working command behind.
+      * `bin` did not match what actually shipped, so Scoop installed the
+        package and left no working command behind. The crate now declares its
+        binary as `hyperdu`, and that is what the archive contains.
       * `homepage` pointed at `github.com/your-org/HyperDiskUsage`, which does
         not exist. Only the URL and hash were ever substituted at release time.
 
@@ -66,7 +65,7 @@ $manifest = [ordered]@{
     }
   }
   # Matches what cargo actually builds. See the note above.
-  bin          = 'hyperdu-cli.exe'
+  bin          = 'hyperdu.exe'
   checkver     = [ordered]@{
     github = $repo
   }

--- a/scripts/package/winget.ps1
+++ b/scripts/package/winget.ps1
@@ -31,7 +31,7 @@
 
 .EXAMPLE
     pwsh -File scripts/package/winget.ps1 -Version 0.5.0-beta.1 `
-        -InstallerUrl https://example.invalid/hyperdu-cli.exe `
+        -InstallerUrl https://example.invalid/hyperdu.exe `
         -InstallerSha256 0000000000000000000000000000000000000000000000000000000000000000
 #>
 Param(
@@ -85,7 +85,7 @@ Platform:
 MinimumOSVersion: 10.0.17763.0
 InstallerType: portable
 Commands:
-  - hyperdu-cli
+  - hyperdu
 ReleaseDate: $(Get-Date -Format 'yyyy-MM-dd')
 Installers:
   - Architecture: x64


### PR DESCRIPTION
`hyperdu` で起動できるようにします。

## 何が問題だったか

`hyperdu-cli` に `[[bin]]` が無く、cargo がパッケージ名でバイナリを作っていました。そのため `cargo install hyperdu-cli` で入るコマンドは `hyperdu-cli` でした。

一方 **deb と rpm は `/usr/bin/hyperdu` として入れています**。導入経路によってコマンド名が違う状態で、利用者が最初に叩く名前が入りませんでした。

`[[bin]] name = "hyperdu"` を宣言して揃えます。**クレート名は `hyperdu-cli` のまま**で、`ripgrep` が `rg` を入れるのと同じ形です。

`0.5.0-beta.1` は公開済みでバージョンを再利用できないため **`0.5.0-beta.2`** にしました。

## 途中で見つけたテストの不備

改名したのにテストが通りました。おかしいので中を見たところ、`du_golden.rs` が**バイナリを見つけられないと黙って合格**していました。

```rust
let exe = bin_path();
if std::fs::metadata(&exe).is_err() {
    eprintln!("skip: test binary not found at {exe}");
    return;                      // ← 何も検証せずに通る
}
```

`bin_path()` は `std::env::var` で 3 通り試し、最後は `target/debug/hyperdu-cli` を決め打ちしていました。改名でどれも外れ、**CLI を一度も起動せずに `ok` を返して**いました。

`env!("CARGO_BIN_EXE_hyperdu")` に変えました。cargo がコンパイル時に設定するので、名前が違えばビルドが落ちます。スキップ経路も削除しました。

```
修正前: test result: ok. 1 passed ... finished in 0.00s   ← 起動していない
修正後: test result: ok. 1 passed ... finished in 1.47s   ← 実際に起動
```

**これは #41 のパリティテストと同じ形の不備**で、CLI 側にも同じものがありました。

`index_commands.rs` は `env!` を使っていたため改名でコンパイルエラーになりますが、`#![cfg(target_os = "linux")]` のため Windows では検出できません。**WSL で確認しました。**

## 追随した箇所

**コマンド／バイナリとしての参照だけ**を変え、クレート名・資産名・ディレクトリ名は保持しています。

| | 対象 |
|---|---|
| **変更** | `target/{release,debug}/hyperdu-cli`、`hyperdu-cli.exe`、`./hyperdu-cli`、コマンド行の `hyperdu-cli` |
| **保持** | `-p hyperdu-cli`、`cargo install hyperdu-cli`、`crates.io/crates/...`、`hyperdu-cli/` パス、`hyperdu-cli-windows-*.zip` などの資産名 |

特に効くもの:

| ファイル | なぜ重要か |
|---|---|
| `winget.ps1` の `Commands` | **portable インストールで PATH に作るシムの名前**。直さないと `winget install` 後に `hyperdu` で起動できない |
| `scoop.ps1` の `bin` | 同様 |
| `setup-hyperdu.sh` / `.ps1` | **導入済みか判定するコマンド名**。旧名のままだと常に「未導入」と誤判定する |

`package_release.sh` / `.ps1` は **cargo の JSON 出力から実際のパスを取得**する作りなので、改名の影響を受けません（確認済み）。

## 検証

| 検証 | 結果 |
|---|---|
| Windows `cargo test --workspace` | **220 件通過 / 16 スイート** |
| **Linux（WSL）** `cargo test -p hyperdu-cli` | **5 件通過**（`index_commands` の 4 件を含む） |
| `cargo clippy --workspace --all-targets` | 警告 0 |
| `scripts/lint/paths.sh` | 91 件の参照がすべて解決 |
| 実バイナリ | `hyperdu --version` → `hyperdu 0.5.0-beta.2` |

## マージ後に必要なこと

**`hyperdu-cli 0.5.0-beta.2` を crates.io に公開**する必要があります。beta.1 は `hyperdu-cli` というコマンドを入れるため、このままでは利用者が `hyperdu` を使えません。

`hyperdu-core` / `hyperdu-mcp` / `hyperdu-gui` は変更なしのため再公開不要です。
