### PR TITLE
feat: GitHub Pages に日英 2 言語の公開サイトを追加する

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,62 @@
+name: pages
+
+# Builds the project site from `site/` and publishes it to GitHub Pages.
+#
+# Not the built-in "deploy from a folder" setting: that would point Jekyll at
+# `docs/`, which holds design notes and benchmark records written for
+# contributors. Those would end up rendered as site pages, burying the two that
+# visitors actually arrive for.
+
+on:
+  push:
+    branches: [main]
+    # Only the site and this workflow affect the output. Rust changes rebuild
+    # nothing here, and a deploy per source commit would be noise.
+    paths:
+      - 'site/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# A superseded deploy is not worth finishing, but cancelling one that is already
+# publishing can leave the site half-updated, so let it run out.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Works out the base path for a project site (/<repo>/) and hands it to
+      # Jekyll, so `relative_url` resolves without the prefix being written down
+      # in a second place.
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./site
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v4
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "hyperdu-cli"
-version = "0.5.0-beta.1"
+version = "0.5.0-beta.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/site/_config.yml
+++ b/site/_config.yml
@@ -1,0 +1,42 @@
+# Jekyll configuration for the project site.
+#
+# The site lives in `site/` rather than `docs/` because `docs/` already holds
+# design notes and benchmark records written for contributors, not visitors.
+# Rendering those through a site theme would bury the pages people arrive for.
+
+title: HyperDU
+description: >-
+  Fast cross-platform disk usage analyzer. Finds what is filling a disk, and
+  which of it can be safely freed.
+
+# GitHub Pages serves a project site under /<repo>/, so every internal link has
+# to carry that prefix. Getting this wrong is the usual reason a project site
+# renders with no stylesheet.
+url: https://automationjp.github.io
+baseurl: /HyperDiskUsage
+
+repository: automationjp/HyperDiskUsage
+
+# The two language trees. The layout builds its switcher from this list, so
+# adding a language here and a page under `site/<code>/` is all it takes.
+languages:
+  - code: ja
+    label: 日本語
+    path: /
+  - code: en
+    label: English
+    path: /en/
+
+# Version numbers appear in install commands on both pages. Keeping them here
+# means a release updates one place instead of six.
+versions:
+  cli: 0.5.0-beta.2
+  mcp: 0.5.0-beta.1
+  gui: 0.5.0-beta.1
+
+# No theme: the site is one page per language, and a theme's layouts would be
+# more to work around than to use.
+plugins: []
+
+exclude:
+  - README.md

--- a/site/_layouts/default.html
+++ b/site/_layouts/default.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: 'ja' }}">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{{ page.title | default: site.title }}</title>
+<meta name="description" content="{{ page.description | default: site.description }}">
+
+{%- comment -%}
+Point search engines and language switchers at the other tree. Without these a
+visitor who lands on the wrong language has no signal that the other exists.
+{%- endcomment -%}
+{%- for lang in site.languages %}
+<link rel="alternate" hreflang="{{ lang.code }}" href="{{ lang.path | prepend: site.baseurl | prepend: site.url }}">
+{%- endfor %}
+
+<meta property="og:title" content="{{ page.title | default: site.title }}">
+<meta property="og:description" content="{{ page.description | default: site.description }}">
+<meta property="og:type" content="website">
+<link rel="stylesheet" href="{{ '/assets/style.css' | relative_url }}">
+</head>
+<body>
+
+<header class="site-head">
+  <div class="wrap head-inner">
+    <a class="brand" href="{{ page.home_path | default: '/' | relative_url }}">HyperDU</a>
+    <nav class="lang-switch" aria-label="{{ page.lang_switch_label | default: 'Language' }}">
+      {%- for lang in site.languages %}
+      <a href="{{ lang.path | relative_url }}"
+         {%- if lang.code == page.lang %} class="is-current" aria-current="true"{% endif %}
+         hreflang="{{ lang.code }}">{{ lang.label }}</a>
+      {%- endfor %}
+    </nav>
+  </div>
+</header>
+
+<main class="wrap">
+{{ content }}
+</main>
+
+<footer class="site-foot">
+  <div class="wrap">
+    <p>
+      <a href="https://github.com/{{ site.repository }}">GitHub</a> ·
+      <a href="https://crates.io/crates/hyperdu-cli">crates.io</a> ·
+      MIT
+    </p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -1,0 +1,207 @@
+/* One page per language, so the whole sheet fits here. No build step and no
+   framework: the page has to render before anyone decides whether a disk tool
+   that claims to be fast is worth their time. */
+
+:root {
+  --bg: #0d1117;
+  --surface: #161b22;
+  --border: #30363d;
+  --text: #e6edf3;
+  --muted: #9198a1;
+  --accent: #4ea1ff;
+  --accent-dim: #1f6feb;
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", "Hiragino Sans",
+    "Noto Sans JP", Meiryo, sans-serif;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #ffffff;
+    --surface: #f6f8fa;
+    --border: #d1d9e0;
+    --text: #1f2328;
+    --muted: #59636e;
+    --accent: #0969da;
+    --accent-dim: #0969da;
+  }
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--sans);
+  line-height: 1.75;
+  font-size: 16px;
+  -webkit-text-size-adjust: 100%;
+}
+
+.wrap {
+  max-width: 52rem;
+  margin: 0 auto;
+  padding: 0 1.25rem;
+}
+
+/* ---- header ---- */
+
+.site-head {
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.head-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding-top: 0.75rem;
+  padding-bottom: 0.75rem;
+}
+
+.brand {
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 1.05rem;
+  color: var(--text);
+  text-decoration: none;
+  letter-spacing: -0.02em;
+}
+
+.lang-switch { display: flex; gap: 0.5rem; }
+
+.lang-switch a {
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.85rem;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+}
+
+.lang-switch a:hover { color: var(--text); border-color: var(--border); }
+
+.lang-switch a.is-current {
+  color: var(--text);
+  background: var(--bg);
+  border-color: var(--border);
+}
+
+/* ---- content ---- */
+
+main { padding: 3rem 1.25rem 4rem; }
+
+h1 {
+  font-size: clamp(2rem, 5vw, 2.75rem);
+  line-height: 1.25;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.75rem;
+}
+
+h2 {
+  font-size: 1.4rem;
+  letter-spacing: -0.01em;
+  margin: 3rem 0 0.75rem;
+  padding-top: 1.75rem;
+  border-top: 1px solid var(--border);
+}
+
+h3 { font-size: 1.05rem; margin: 2rem 0 0.5rem; }
+
+.lede {
+  font-size: 1.15rem;
+  color: var(--muted);
+  margin: 0 0 2rem;
+}
+
+a { color: var(--accent); }
+
+code {
+  font-family: var(--mono);
+  font-size: 0.9em;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0.1em 0.35em;
+}
+
+pre {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1rem 1.1rem;
+  overflow-x: auto;
+  line-height: 1.6;
+}
+
+pre code {
+  background: none;
+  border: 0;
+  padding: 0;
+  font-size: 0.875rem;
+}
+
+/* ---- tables ---- */
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.25rem 0;
+  font-size: 0.925rem;
+}
+
+th, td {
+  text-align: left;
+  padding: 0.55rem 0.7rem;
+  border-bottom: 1px solid var(--border);
+}
+
+th {
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Timings only compare at a glance when the digits share a width. */
+td:nth-child(n+2) { font-variant-numeric: tabular-nums; }
+
+tbody tr:hover { background: var(--surface); }
+
+strong { color: var(--text); font-weight: 650; }
+
+/* ---- callout ---- */
+
+blockquote {
+  margin: 1.5rem 0;
+  padding: 0.85rem 1.1rem;
+  background: var(--surface);
+  border-left: 3px solid var(--accent-dim);
+  border-radius: 0 6px 6px 0;
+  color: var(--muted);
+}
+
+blockquote p { margin: 0.35rem 0; }
+
+/* ---- footer ---- */
+
+.site-foot {
+  border-top: 1px solid var(--border);
+  padding: 1.5rem 0;
+  color: var(--muted);
+  font-size: 0.875rem;
+}
+
+.site-foot a { color: var(--muted); }
+.site-foot p { margin: 0; }
+
+ul { padding-left: 1.3rem; }
+li { margin: 0.35rem 0; }
+
+hr { border: 0; border-top: 1px solid var(--border); margin: 2.5rem 0; }

--- a/site/en/index.md
+++ b/site/en/index.md
@@ -1,0 +1,153 @@
+---
+layout: default
+lang: en
+home_path: /en/
+lang_switch_label: Language
+permalink: /en/
+title: "HyperDU — find what is filling the disk"
+description: "Fast cross-platform disk usage analysis, measured on Windows and Linux. Answers what is using space and which of it is safe to delete."
+---
+
+# Find what is filling the disk
+
+<p class="lede">
+When a disk fills up, the useful question is not just what is large. It is <strong>which of it is safe to delete</strong>. HyperDU answers both.
+</p>
+
+```bash
+hyperdu /path --top 20
+```
+
+## Speed
+
+Measured on one machine (Ryzen 9 3900X, NVMe SSD) on 2026-09-07.
+
+### Windows — 101,368 files / 2.96 GB
+
+| Tool | Time | Ratio |
+|---|---|---|
+| **HyperDU** | **251 ms** | — |
+| robocopy `/L /S` | 14,362 ms | **57×** |
+| GNU du 8.32 (MSYS2) | 12,871 ms | **51×** |
+
+### Linux (WSL2, ext4) — 712,374 files
+
+| Tool | Time | Ratio |
+|---|---|---|
+| **HyperDU** | **191 ms** | — |
+| du (uutils coreutils 0.8.0) | 2,900 ms | **15×** |
+
+Two comparisons on purpose. MSYS2's `du` goes through a POSIX compatibility
+layer, which puts it at a structural disadvantage on Windows, so **robocopy**
+was measured too: Microsoft's own tool, native API, no emulation. It is still
+57× slower.
+
+On Linux, `du` is Ubuntu 26.04's default, which is uutils coreutils — a Rust
+implementation. That makes it a **Rust-to-Rust** comparison.
+
+> **Scan volumes were verified identical every time.** robocopy and HyperDU
+> agreed exactly: 101,368 files, 2,956,477,017 bytes. Neither side is skipping
+> work to look fast.
+
+Ratios depend heavily on tree shape and storage. Deep, narrow trees narrow the
+gap, and on spinning disks or network filesystems the work becomes I/O bound.
+**Full numbers, method, and the less flattering results** are in
+[docs/benchmarks.md](https://github.com/{{ site.repository }}/blob/main/docs/benchmarks.md).
+
+## Why it is fast
+
+- **Per-platform bulk enumeration** — `getdents64` + `statx` on Linux,
+  `NtQueryDirectoryFile` on Windows (allocation size and file id arrive with the
+  batch, so hardlink dedupe costs no extra syscalls), `getattrlistbulk` on macOS
+- **Reads the NTFS `$MFT` directly** when run elevated against a volume root
+- **Work stealing** across per-worker LIFO deques, taking from the shallow end so
+  a thief gets a large subtree
+
+## Install
+
+### crates.io
+
+```bash
+cargo install hyperdu-cli --version {{ site.versions.cli }}
+```
+
+Prereleases are not selected by default, so `--version` is required. **The crate
+is `hyperdu-cli`; the command it installs is `hyperdu`** — the same shape as
+ripgrep installing `rg`.
+
+### Windows
+
+```powershell
+winget install automationjp.HyperDU
+scoop install hyperdu
+```
+
+> **Not available yet.** The manifests are generated, but winget needs a pull
+> request to [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs)
+> and Scoop needs a bucket entry. Neither has been submitted.
+
+### From source
+
+```bash
+git clone https://github.com/{{ site.repository }}.git
+cd HyperDiskUsage
+cargo install --path hyperdu-cli
+```
+
+## For agents
+
+Three surfaces let an agent such as Claude or Codex receive disk usage as
+structured data and decide what is safe to remove. **They do not depend on each
+other, so you can adopt any one alone.**
+
+| Surface | Usable alone |
+|---|---|
+| MCP server | Any MCP client |
+| Agent Skill | Drives the CLI, so no MCP needed |
+| Agent Plugin | Bundles the other two |
+
+```bash
+cargo install hyperdu-mcp --version {{ site.versions.mcp }}
+claude mcp add --transport stdio hyperdu -- hyperdu-mcp
+```
+
+Three tools, in the order the questions actually arrive:
+
+| Tool | Answers |
+|---|---|
+| `list_volumes` | Which volume is short on space |
+| `scan_path` | What is large inside it |
+| `find_reclaimable` | Which of that can be **rebuilt**, with idle days |
+
+**There is no delete tool, deliberately.** Exposing one would create a path for
+an agent to destroy data without a human in the loop. A wrong report can be
+corrected; a wrong `rm -rf` cannot.
+
+`find_reclaimable` does not classify `target/` by name alone. Without a
+`Cargo.toml` beside it, that directory is someone's data, and reporting it as
+reclaimable would be the failure that makes the tool unusable.
+
+## Where this stands
+
+- **Beta.** The API and the tool surface may still change
+- **No GitHub Releases yet.** Today the paths in are `cargo install` or a source
+  build
+- **macOS is unverified on hardware** — it builds, but has not been run
+- The Linux figures come from WSL2 and may differ from bare metal
+
+## Usage
+
+```bash
+# largest directories
+hyperdu /path --top 20
+
+# structured output
+hyperdu /path --json out.json
+
+# drop-in for du
+hyperdu --compat gnu -sh /var/log
+alias du='hyperdu --compat gnu'
+```
+
+See the [README](https://github.com/{{ site.repository }}#readme) for the full
+option list.

--- a/site/index.md
+++ b/site/index.md
@@ -1,0 +1,128 @@
+---
+layout: default
+lang: ja
+home_path: /
+lang_switch_label: 言語
+title: "HyperDU — 何がディスクを埋めているかを、すぐに"
+description: "Windows と Linux で実測した高速なディスク使用量解析。何が容量を食っていて、そのうち何を消してよいかを答えます。"
+---
+
+# 何がディスクを埋めているか
+
+<p class="lede">
+容量が尽きたとき知りたいのは「何が大きいか」だけではありません。<strong>そのうち何を消してよいか</strong>です。HyperDU は両方に答えます。
+</p>
+
+```bash
+hyperdu C:\ --top 20
+```
+
+## 速度
+
+同一マシン（Ryzen 9 3900X / NVMe SSD）での実測です。計測日 2026-09-07。
+
+### Windows — 101,368 ファイル / 2.96 GB
+
+| ツール | 実行時間 | 倍率 |
+|---|---|---|
+| **HyperDU** | **251 ms** | — |
+| robocopy `/L /S` | 14,362 ms | **57×** |
+| GNU du 8.32 (MSYS2) | 12,871 ms | **51×** |
+
+### Linux（WSL2 / ext4） — 712,374 ファイル
+
+| ツール | 実行時間 | 倍率 |
+|---|---|---|
+| **HyperDU** | **191 ms** | — |
+| du (uutils coreutils 0.8.0) | 2,900 ms | **15×** |
+
+比較対象は意図的に 2 種類用意しています。MSYS2 の `du` は POSIX 互換層を通るぶん Windows では構造的に不利なので、**互換層を通らない Windows 純正の robocopy** も測りました。それでも 57 倍です。
+
+Linux の `du` は Ubuntu 26.04 既定の uutils（Rust 実装）なので、**Rust 対 Rust** の比較になります。
+
+> **走査量が一致していることを毎回確認しています。** robocopy と HyperDU はファイル数 101,368、バイト数 2,956,477,017 が完全一致しました。片方が何かを除外して速く見えている、ということはありません。
+
+倍率はツリーの形とストレージに強く依存します。深く狭い木では差が縮み、HDD やネットワーク越しでは I/O 律速になります。**環境・手順・不利な結果を含む全数値**は [docs/benchmarks.md](https://github.com/{{ site.repository }}/blob/main/docs/benchmarks.md) にあります。
+
+## 速い理由
+
+- **OS ごとの一括列挙 API** — Linux は `getdents64` + `statx`、Windows は `NtQueryDirectoryFile`（物理サイズとファイル ID が列挙結果に含まれるため、ハードリンク重複排除に追加のシステムコールが要りません）、macOS は `getattrlistbulk`
+- **NTFS の `$MFT` 直読み** — Windows で管理者権限かつボリュームルートを指定した場合
+- **ワークスティーリング** — ワーカーごとの LIFO デックから、浅い側＝大きなサブツリーを盗みます
+
+## インストール
+
+### crates.io
+
+```bash
+cargo install hyperdu-cli --version {{ site.versions.cli }}
+```
+
+ベータ版のため `--version` の明示が要ります。**クレート名は `hyperdu-cli` ですが、入るコマンドは `hyperdu` です**（`ripgrep` が `rg` を入れるのと同じ形）。
+
+### Windows
+
+```powershell
+winget install automationjp.HyperDU
+scoop install hyperdu
+```
+
+> **まだ使えません。** マニフェストは生成できますが、winget は [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) への PR、scoop はバケットへの登録が別途必要で、いずれも未提出です。
+
+### ソースから
+
+```bash
+git clone https://github.com/{{ site.repository }}.git
+cd HyperDiskUsage
+cargo install --path hyperdu-cli
+```
+
+## エージェント連携
+
+Claude や Codex のようなエージェントが、**容量の状況を構造化データとして受け取り、何を消してよいか判断できる**ようにする 3 つの面を同梱しています。**互いに依存しないので、どれか 1 つだけを採用できます。**
+
+| 面 | 単独で使えるか |
+|---|---|
+| MCP サーバ | 任意の MCP クライアント |
+| Agent Skill | CLI を叩くので MCP 不要 |
+| Agent Plugin | 上 2 つを束ねるだけ |
+
+```bash
+cargo install hyperdu-mcp --version {{ site.versions.mcp }}
+claude mcp add --transport stdio hyperdu -- hyperdu-mcp
+```
+
+公開しているツールは 3 つで、容量逼迫時に必要になる順に対応します。
+
+| ツール | 答えること |
+|---|---|
+| `list_volumes` | どのドライブが逼迫しているか |
+| `scan_path` | その中で何が大きいか |
+| `find_reclaimable` | そのうち**再生成できる**のはどれか（放置日数つき） |
+
+**削除ツールは意図的に持たせていません。** エージェントが人間の確認なしにデータを壊す経路を作らないためです。誤った報告は取り返しがつきますが、誤った `rm -rf` はつきません。
+
+`find_reclaimable` は `target/` を名前だけで判定しません。兄弟に `Cargo.toml` が無ければそれは誰かのデータであり、再生成可能と報告するのは危険だからです。
+
+## いま素直に書いておくこと
+
+- **ベータ版です。** API とツールの粒度は変わる可能性があります
+- **GitHub Releases はまだありません。** 現時点の導入経路は `cargo install` かソースビルドです
+- **macOS は実機未検証**です（ビルドは通ります）
+- Linux の実測値は WSL2 上のもので、ベアメタルとは異なる可能性があります
+
+## 使い方
+
+```bash
+# 上位 20 件
+hyperdu /path --top 20
+
+# 構造化出力
+hyperdu /path --json out.json
+
+# du の代替として
+hyperdu --compat gnu -sh /var/log
+alias du='hyperdu --compat gnu'
+```
+
+詳細は [README](https://github.com/{{ site.repository }}#readme) を参照してください。


### PR DESCRIPTION
`site/` に Jekyll のソースを置き、GitHub Actions でデプロイします。

公開先: **https://automationjp.github.io/HyperDiskUsage/**

## `docs/` を使わなかった理由

Pages の「フォルダから配信」設定を使うと `docs/` が対象になりますが、そこには**設計文書とベンチマークの記録**が入っています。いずれも貢献者向けで、サイトのテーマで描画すると**訪問者が実際に来る 2 ページが埋もれます**。

`site/` を分けて Actions からビルドすれば `docs/` に触れずに済みます。

## 構成

```
site/
├── _config.yml            baseurl、言語一覧、バージョン
├── _layouts/default.html  共通レイアウトと言語切替
├── assets/style.css       スタイル（ライト / ダーク対応）
├── index.md               日本語（/）
└── en/index.md            英語（/en/）
```

言語は `_config.yml` の `languages` に列挙してあり、**レイアウトがそこから切替リンクと `hreflang` を生成**します。言語を足すときは、その配列と `site/<code>/` を足すだけです。

バージョン番号は `_config.yml` の `versions` にまとめました。インストール手順が両ページにあるため、リリースのたびに 6 箇所直すのを避けています。

## 内容

数字は `docs/benchmarks.md` と**同じ実測値**をそのまま載せています。robocopy と HyperDU で走査量が完全一致していることも明記しました。読者が倍率だけを見て判断しないよう、ツリーの形とストレージに依存する点も添えています。

**まだ使えないものは、使えないと書きました。**

| 項目 | 記載 |
|---|---|
| winget / scoop | マニフェストは生成できるが**未提出** |
| GitHub Releases | **まだ 1 つも無い** |
| macOS | ビルドは通るが**実機未検証** |

## そのほか

**`Cargo.lock` を更新しました。** #56 でバージョンを `beta.2` に上げたときステージから漏れており、`Cargo.toml` と食い違ったままでした。

## 検証

- `site/_config.yml` と `.github/workflows/pages.yml` の YAML 妥当性を確認
- 両ページの front matter を確認（`lang` / `layout`）
- `cargo check --workspace` 通過（`Cargo.lock` の整合を確認）
- 使用アクションは GitHub 公式ドキュメントで版を確認（`configure-pages@v5`、`jekyll-build-pages@v1`、`upload-pages-artifact@v4`、`deploy-pages@v4`）

**Jekyll のビルド自体はローカルに Ruby が無いため未実行**です。CI の初回実行が実質の検証になります。

## マージ後に必要な設定

**リポジトリ設定で Pages を有効化し、ソースを「GitHub Actions」にする必要があります。** これはリポジトリの設定変更なので、私からは実行していません。

Settings → Pages → Source を `GitHub Actions` に変更してください。ご希望があれば `gh api` 経由で私が設定することもできます。
