### PR TITLE
docs: READMEを初見ユーザー向けに再設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,551 +1,342 @@
-# HyperDiskUsage (HyperDU)
+# HyperDU
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Rust](https://img.shields.io/badge/rust-%23000000.svg?style=flat&logo=rust&logoColor=white)](https://www.rust-lang.org)
-[![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-blue)](https://github.com/automationjp/HyperDiskUsage)
+> **何がディスクを埋めているかを、すぐに。**  
+> Rust 製の高速・クロスプラットフォームなディスク使用量アナライザー。CLI、GUI、GNU `du` 互換モード、AI エージェント向け MCP / Skill を提供します。
 
-**HyperDU** は、高速なディスク使用量分析を目指した Rust 製ツールです。並列処理とOS固有APIの最適化により、従来のツールより高速に動作する可能性があります。
+[![CI](https://github.com/automationjp/HyperDiskUsage/actions/workflows/ci.yml/badge.svg)](https://github.com/automationjp/HyperDiskUsage/actions/workflows/ci.yml)
+[![Crates.io](https://img.shields.io/crates/v/hyperdu-cli.svg)](https://crates.io/crates/hyperdu-cli)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Rust](https://img.shields.io/badge/Rust-1.75%2B-black?logo=rust)](https://www.rust-lang.org/)
+[![Platform](https://img.shields.io/badge/Windows%20%7C%20Linux-tested-blue)](#platform-status)
 
-> **⚠️ 動作確認について**: Windows と Linux は実機で検証済みです（CI でも両方をテストしています）。macOS はビルドのみで実機検証していません。
-
-## 🚀 特徴
-
-- **高速スキャン**: 並列処理とプラットフォーム最適化による高速化を目指しています
-- **du 互換モード**: `--compat gnu` オプションで GNU du 風の出力形式に対応
-- **マルチプラットフォーム対応**: Windows (検証済み), Linux (検証済み), macOS (実機未検証)
-- **並列処理**: ワークスティーリングアルゴリズムによる効率的な並列化
-- **プラットフォーム最適化**:
-  - Linux: `getdents64` システムコール + `statx`
-  - Windows: `NtQueryDirectoryFile` による一括列挙（物理サイズ・ファイルIDを列挙結果から直接取得。`FindFirstFileExW` はフォールバック）
-  - macOS: `getattrlistbulk` による一括取得
-- **リアルタイムチューニング**: 実行中にパフォーマンスパラメータを自動調整
-- **多様な出力形式**: du互換出力、CSV、JSON、独自の詳細表示
-- **GUI版も提供**: CLI版に加えて、直感的なGUIアプリケーション
-
-## 📊 パフォーマンス
-
-同一マシン（Ryzen 9 3900X / NVMe SSD）での実測です。計測日 2026-09-07。
-
-### Windows — `C:\Users\<user>\.cargo\registry`（101,368 ファイル / 2.96 GB）
-
-| ツール | 実行時間 | HyperDU 比 |
-|---|---|---|
-| **HyperDU** | **251 ms** | — |
-| robocopy `/L /S`（Windows 純正・ネイティブ API） | 14,362 ms | **57× 遅い** |
-| GNU du 8.32（MSYS2） | 12,871 ms | **51× 遅い** |
-
-### Linux（WSL2 / ext4） — `/var`（712,374 ファイル）
-
-| ツール | 実行時間 | HyperDU 比 |
-|---|---|---|
-| **HyperDU** | **191 ms** | — |
-| du（uutils coreutils 0.8.0） | 2,900 ms | **15× 遅い** |
-
-3〜5 回の最小値です。**走査量が一致していることを毎回確認**しています（robocopy と HyperDU はファイル数 101,368、バイト数 2,956,477,017 が完全一致）。
-
-比較対象は意図的に 2 種類用意しています。MSYS2 の du は POSIX 互換層を通るぶん Windows では構造的に不利なので、**互換層を通らない Windows 純正の robocopy** も測りました。それでも 57 倍です。Linux の `du` は Ubuntu 26.04 の既定である uutils（Rust 実装）なので、**Rust 対 Rust** の比較になります。
-
-倍率はツリーの形とストレージに強く依存します。深く狭い木では差が縮み、HDD やネットワーク越しでは I/O 律速になります。**環境・手順・不利な結果を含む全数値は [docs/benchmarks.md](docs/benchmarks.md) にあります。**
-
-### パフォーマンスの秘密
-
-1. **プラットフォーム最適化**
-   - Linux: `getdents64` システムコール + `statx`
-   - Windows: `NtQueryDirectoryFile`（`FileIdFullDirectoryInformation`）で 128KiB 単位に一括取得。割り当てサイズとファイル ID も同時に得られるため、物理サイズ計算やハードリンク重複排除でファイル毎のシステムコールが発生しません（MSVC ビルド既定。`HYPERDU_WIN_USE_NTQUERY=0` で `FindFirstFileExW` 経路に切替、`HYPERDU_WIN_DIR_BUF_KB` で列挙バッファサイズを変更）
-   - macOS: `getattrlistbulk` による名称・型・サイズのバルク取得
-
-2. **並列処理**
-   - ワーカー毎の LIFO デック＋ワークスティーリング（浅い＝大きなサブツリーから盗む）による動的負荷分散
-   - 処理中ジョブを数えて終了判定するため、キューが一瞬空いてもワーカーが早期終了しない
-   - 巨大ディレクトリの継続ジョブは高優先度キューで先に処理
-
-3. **メモリ最適化**
-   - `mimalloc` アロケータ（オプション機能）
-   - `ahash` による高速ハッシュマップ
-   - Aho-Corasick による高速パターンマッチング
-
-## 📦 インストール
-
-### crates.io から（推奨・現在使える唯一の配布経路）
-
-```bash
-# CLI
-cargo install hyperdu-cli --version 0.5.0-beta.2
-
-# エージェント向け MCP サーバ
-cargo install hyperdu-mcp --version 0.5.0-beta.2
-
-# GUI（任意）
-cargo install hyperdu-gui --version 0.5.0-beta.2
-```
-
-ベータ版のため、`--version` の明示が要ります（プレリリースは既定で選ばれません）。
-
-**クレート名は `hyperdu-cli` ですが、入るコマンドは `hyperdu` です。** `ripgrep` が `rg` を入れるのと同じ形で、deb / rpm パッケージのコマンド名とも揃います。
-
-### 準備中の経路（GitHub Release 公開後に有効）
-
-> **以下はまだ使えません。** 公開リリースが 1 つも無いためです。最初のタグ（`v0.5.0-beta.2`）を打つと `release.yml` が production ビルドの成果物を公開し、事前ビルドのリンクが有効になります。winget と scoop はさらに [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) への PR とバケット登録が必要で、いずれも未提出です。それまでは上の crates.io 経路を使ってください。
-
-<details>
-<summary>Windows のパッケージマネージャ（準備中）</summary>
-
-```powershell
-winget install automationjp.HyperDU
-```
-
-```powershell
-scoop install hyperdu
-```
-
-</details>
-
-<details>
-<summary>事前ビルド（準備中）</summary>
-
-GitHub Releases の最新版への直接リンクです。リリース公開後はダウンロードして展開するだけで実行できます。
-
-- Windows (x86_64)
-  - CLI: [hyperdu-cli-windows-x86_64-generic.zip](releases/latest/download/hyperdu-cli-windows-x86_64-generic.zip)
-  - GUI: [hyperdu-gui-windows-x86_64-generic.zip](releases/latest/download/hyperdu-gui-windows-x86_64-generic.zip)
-- Linux (x86_64, glibc)
-  - CLI: [hyperdu-cli-linux-x86_64-generic.zip](releases/latest/download/hyperdu-cli-linux-x86_64-generic.zip)
-  - GUI: [hyperdu-gui-linux-x86_64-generic.zip](releases/latest/download/hyperdu-gui-linux-x86_64-generic.zip)
-- Linux (x86_64, musl・CLIのみ)
-  - CLI: [hyperdu-cli-linux-x86_64-musl.zip](releases/latest/download/hyperdu-cli-linux-x86_64-musl.zip)
-- Linux (aarch64, glibc)
-  - CLI: [hyperdu-cli-linux-aarch64-generic.zip](releases/latest/download/hyperdu-cli-linux-aarch64-generic.zip)
-  - GUI: [hyperdu-gui-linux-aarch64-generic.zip](releases/latest/download/hyperdu-gui-linux-aarch64-generic.zip)
-
-その他のアセット（チェックサム等）は [最新リリース一覧](releases/latest) を参照してください。
-
-</details>
-
-### ソースからビルド
-
-```bash
-# リポジトリのクローン
-git clone https://github.com/automationjp/HyperDiskUsage.git
-cd HyperDiskUsage
-
-# リリースビルド（最高パフォーマンス）
-RUSTFLAGS="-C target-cpu=native" cargo build --release --all
-
-# インストール
-cargo install --path hyperdu-cli
-cargo install --path hyperdu-gui  # GUI版（オプション）
-```
-
-### 必要な環境
-
-- Rust 1.75 以降
-- **Windows**: Visual Studio 2019 以降または MinGW-w64 (動作確認済み)
-- **Linux**: 検証済み（Amazon Linux 2023 / xfs、WSL2 / ext4）
-- **macOS**: 実機未検証
-
-## 🤖 エージェント連携（MCP / Skill / Plugin）
-
-Claude や Codex のようなエージェントが、**容量の状況を構造化データとして受け取り、何を消してよいか判断できる**ようにするための 3 つの面を同梱しています。
-
-| 面 | 仕様 | 単独で使えるか |
-|---|---|---|
-| MCP サーバ | [Model Context Protocol](https://modelcontextprotocol.io/) | 任意の MCP クライアント |
-| Agent Skill | [agentskills.io](https://agentskills.io/) | **CLI を叩くので MCP 不要** |
-| Agent Plugin | [agent-plugins.org](https://agent-plugins.org/) | 上 2 つを束ねるだけ |
-
-**互いに依存しないので、どれか 1 つだけを採用できます。**
-
-### MCP サーバ
-
-```bash
-cargo install hyperdu-mcp --version 0.5.0-beta.2
-
-claude mcp add --transport stdio hyperdu -- hyperdu-mcp   # Claude Code
-codex mcp add hyperdu -- hyperdu-mcp                      # Codex
-```
-
-公開しているツールは 3 つで、容量逼迫時に必要になる順に対応します。
-
-| ツール | 答えること |
-|---|---|
-| `list_volumes` | どのドライブが逼迫しているか |
-| `scan_path` | その中で何が大きいか |
-| `find_reclaimable` | そのうち**再生成できる**のはどれか（放置日数つき） |
-
-**削除ツールは意図的に持たせていません。** エージェントが人間の確認なしにデータを壊す経路を作らないためです。誤った報告は取り返しがつきますが、誤った `rm -rf` はつきません。
-
-`find_reclaimable` は `target/` を名前だけで判定しません。兄弟に `Cargo.toml` が無ければそれは誰かのデータであり、再生成可能と報告するのは危険だからです。
-
-### Agent Skill / Plugin
-
-`plugin/` 配下に入っています。セットアップスクリプトが両バイナリの導入と MCP 登録まで面倒を見ます。
-
-```bash
-plugin/skills/disk-space-triage/scripts/setup-hyperdu.sh            # 導入 + 登録方法の表示
-plugin/skills/disk-space-triage/scripts/setup-hyperdu.sh --register # 登録まで実行
-```
-
-詳細は [plugin/README.md](plugin/README.md) を参照してください。
-
-## 🎯 使い方
-
-### du コマンドの代替として（互換モード）
-
-```bash
-# 従来の du を HyperDU に置き換え
-alias du='hyperdu --compat gnu'
-
-# du と同じオプションがそのまま使える
-hyperdu --compat gnu -sh /var/log
-hyperdu --compat gnu -ak /home --max-depth=2
-hyperdu --compat gnu -b --time /usr/share
-
-# du 互換の出力形式で高速動作を目指しています
-```
-
-### HyperDU 独自の高速スキャン
-
-```bash
-# カレントディレクトリをスキャン（デフォルトは高速モード）
-hyperdu .
-
-# ターボモードで最速スキャン
-hyperdu --perf turbo /large/directory
-
-# 進捗表示とライブチューニング付き
-hyperdu /large/directory --progress --tune-log
-
-# 特定のディレクトリを除外して高速化
-hyperdu . --exclude ".git,node_modules,target,build"
-
-# CSV/JSON形式で出力
-hyperdu . --csv output.csv --json output.json
-```
-
-### コマンドラインオプション
-
-```
-USAGE:
-    hyperdu [OPTIONS] <ROOT>
-
-ARGS:
-    <ROOT>    スキャンするディレクトリパス
-
-OPTIONS:
-    -t, --top <N>                上位N個のディレクトリを表示 [default: 30]
-    -e, --exclude <PATTERNS>     除外するパターン（カンマ区切り）
-    -d, --max-depth <DEPTH>      最大再帰深度（0 = 無制限）
-    -m, --min-file-size <BYTES>  最小ファイルサイズ（バイト）
-    -f, --follow-links           シンボリックリンクを追跡
-        --threads <N>            ワーカースレッド数 [default: CPU数]
-        --csv <PATH>             CSV形式で出力
-        --json <PATH>            JSON形式で出力
-        --progress               スキャン進捗を標準出力に表示
-            --progress-every N   進捗をNファイルごとに表示（既定: 8192）
-        --classify MODE          種別分類: basic|deep
-        --class-report PATH      分類結果をJSONへ出力
-        --class-report-csv PATH  分類結果をCSVへ出力
-        --verbose, -v            冗長モード（進捗/ログ詳細 + 既定ファイル名でレポート自動保存）
-        --tune-log               ライブチューニングログを表示
-        --tune-threshold <N>     チューニング閾値（デフォルト: 0.05 = 5%）
-        --tune-only              チューニングのみ実行（推奨値を表示）
-        --tune-secs <N>          チューニング実行時間（秒）
-    -h, --help                   ヘルプを表示
-    -V, --version                バージョンを表示
-```
-
-### 高度な使用例
-
-```bash
-# 1GB以上のファイルのみをカウント
-hyperdu / --min-file-size 1073741824
-
-# 3階層までの深さでスキャン
-hyperdu . --max-depth 3
-
-# 複数の除外パターンを指定
-hyperdu ~/projects --exclude ".git,node_modules,target,build,dist"
-
-# 物理サイズの計算をスキップして高速化（論理サイズのみ）
-hyperdu / --logical-only
-
-# 推定サイズモードで高速スキャン（精度とトレードオフ）
-hyperdu / --approximate
-
-# ライブチューニングのログを表示しながらスキャン
-hyperdu /large/directory --progress --tune-log
-
-# 最適なパラメータを2秒間で測定
-hyperdu /large/directory --tune-only --tune-secs 2
-```
-
-## 🖼️ GUI版
-
-GUI版は `egui` フレームワークを使用した直感的なインターフェースを提供：
-
-```bash
-# GUI版の起動
-hyperdu-gui
-
-# 特定のディレクトリを開いて起動
-hyperdu-gui ~/Documents
-```
-
-### GUI機能
-
-- リアルタイムスキャン表示
-- インタラクティブなツリービュー
-- files/s（平均/直近）とyield値の表示
-- ディレクトリのドリルダウン
-- 結果のエクスポート
-
-## 🔥 パフォーマンス
-
-数値はすべて `scripts/bench/vs_du.sh` による実測です。同スクリプトは、古いバイナリを測ろうとした場合と、両ツールが同じファイル集合を走査していない場合に**エラーで停止**します。
-
-### GNU du 8.32 との比較（EC2 t3.large / xfs / kernel 6.1）
-
-| ツリー | files | dirs | warm | cold |
-|---|---|---|---|---|
-| Linux カーネル | 95,953 | 6,299 | 1.32x | **4.93x** |
-| rust リポジトリ | 62,621 | 4,734 | 1.36x | **5.56x** |
-| git リポジトリ | 4,874 | 242 | 1.00x | 2.02x |
-
-warm は 5 回の最小値、cold は 3 回の burn-in 後に両ツールを交互実行した 5 組の中央値です。ファイル数は 3 つとも `find` と完全一致しています。
-
-### warm の比は物理コア数の関数です
-
-**du は単一スレッド**なので、比は走査対象よりも物理コア数で決まります。上表の t3.large は **2 vCPU = 物理 1 コア + SMT** で、並列化の余地がほぼありません。参考までに WSL2（物理 8 コア / 16 スレッド、ext4）では同じ rust ツリーで **7.18x** です。
-
-**cold こそが実用上の主戦場**です。ディスク使用量の調査は通常 1 回きりで、ページキャッシュは温まっていません。
-
-### Windows
-
-`NtQueryDirectoryFile` + `FileIdFullDirectoryInformation` への変更により、旧実装比 **4.7x**。1 回の列挙でサイズ・割り当てサイズ・ファイル ID が同時に得られるため、ファイルごとのハンドル open が不要です。
-
-### なぜ Linux は Windows より差が小さいのか
-
-構造的な理由があります。`struct dirent64` は `d_ino` / `d_off` / `d_reclen` / `d_type` / `d_name` の 5 フィールド固定で、**サイズを入れる場所がありません**。さらに VFS の `dir_emit()` / `filldir64()` のコールバック署名が `(name, namelen, ino, dtype)` しか受け取らないため、どのファイルシステムであれ列挙時にサイズを返せません。
-
-したがって Linux では**ファイル 1 個につき `statx` が 1 回**必要で、syscall 数はファイル数に比例します（Windows はディレクトリ数に比例）。GNU du も同じ制約下にあるため、warm では両者が同じ壁に当たります。
-
-### du 互換モードでの動作確認
-
-```bash
-# 従来の du コマンド
-du -sh /path/to/directory
-
-# HyperDU で完全互換動作
-hyperdu --compat gnu -sh /path/to/directory
-
-# du 互換の出力形式を目指しています
-```
-
-### プラットフォーム別最適化
-
-- Linux: `getdents64` + `statx`
-
-#### FS戦略の振る舞い（Linux）
-
-- Ext4/XFS/ZFS
-  - getdents_buf_kb=128、prefetch=1（posix_fadvise+readahead/madvise）
-- Btrfs
-  - compute_physical=false（論理サイズ優先）
-  - getdents_buf_kb=128、prefetch=0
-- DrvFS（WSL）/Network（NFS/SMB/SSHFS/9p/fuse）
-  - compute_physical=false、getdents_buf_kb=64、prefetch=0
-  - 推奨 threads: 4（必要に応じてランタイムチューニングが増減）
-
-適用時は stderr に詳細ログを 1 行出力: 例
-
-```
-fs-auto: fs='ext4' strategy='ext4' reason='fstype=ext4' changes=[getdents_buf_kb=128,prefetch=1] for '/data'
-```
-- Windows: `NtQueryDirectoryFile` による列挙（既定）。物理サイズはディレクトリ列挙が返す割り当てサイズ（クラスタ単位）で、GNU du のブロック集計に相当します。`--logical-only` で論理サイズのみを集計できます。`HYPERDU_WIN_USE_NTQUERY=0` を設定すると `FindFirstFileExW` 経路（物理サイズはファイル毎に `GetCompressedFileSizeW`）に切り替わります。`\?\` プレフィックスにより 260 文字を超えるパスも走査します。
-- macOS: `getattrlistbulk` による名称・型・サイズの一括取得
-
-## 🛠️ 開発者向け
-
-### プロジェクト構造
-
-```
-HyperDiskUsage/
-├── hyperdu-core/     # コアスキャンエンジン
-├── hyperdu-cli/      # CLIアプリケーション
-├── hyperdu-gui/      # GUIアプリケーション
-├── scripts/          # ビルド・パッケージングスクリプト
-└── Cargo.toml        # ワークスペース設定
-```
-
-### ビルド機能フラグ
-
-```bash
-# mimalloc アロケータを無効化
-cargo build --release --no-default-features
-
-# Tracy プロファイラサポート
-cargo build --release --features prof-tracy
-
-# Puffin プロファイラサポート
-cargo build --release --features prof-puffin
-
-
-# SIMD プリフェッチ（実験的）
-cargo build --release --features simd-prefetch
-```
-
-### 配布用バイナリの作成
-
-簡易パッケージングスクリプトを同梱：
-
-**Unix/WSL:**
-```bash
-# 基本パッケージング
-bash scripts/package/release.sh
-
-# クロスビルドも対応
-bash scripts/package/release.sh --targets "linux-musl,windows-gnu"
-
-# CPU最適化オプション
-bash scripts/package/release.sh --cpu-flavors "generic,native"
-
-# GUIを省く
-bash scripts/package/release.sh --skip-gui
-```
-
-**Windows (PowerShell):**
-```powershell
-# 基本パッケージング
-powershell -ExecutionPolicy Bypass -File scripts\package\release.ps1
-
-# CPU最適化版
-powershell -ExecutionPolicy Bypass -File scripts\package\release.ps1 -CpuFlavor native
-```
-
-### テスト実行
-
-```bash
-# すべてのテストを実行
-cargo test --all
-
-# ベンチマークを実行
-cargo bench
-
-# 特定のテスト実行
-cargo test -p hyperdu-core test_name
-
-# Clippy による静的解析
-cargo clippy --workspace -- -D warnings
-
-### ベンチと回帰基準
-
-**GNU du との比較には `scripts/bench/vs_du.sh` を使ってください。** 公平性の条件をスクリプト側で強制します。
-
-```
-# warm のみ
-scripts/bench/vs_du.sh /path/to/tree
-
-# cold も測る（drop_caches のため root/sudo が必要）
-scripts/bench/vs_du.sh --cold /path/to/tree1 /path/to/tree2
-```
-
-このスクリプトは以下を**自動で検出して停止**します。いずれも過去に実際にやらかした失敗です。
-
-| 検出 | 背景 |
-|---|---|
-| **古いバイナリ** | `cargo build --features X` が `target/release` を上書きし、後の計測が古いバイナリを測っていた |
-| **走査対象の不一致** | 既定除外の `.git` が `.github` に部分一致し、HyperDU だけ 437 ディレクトリ少なく走査していた。`find` のファイル数と突き合わせる |
-| **cold の最小値** | EBS gp3 のバースト枯渇で同一条件が 0.495s → 0.88s と 1.8 倍ぶれる。最小値はバースト状態だけを拾うため、burn-in → 交互実行 → **中央値**とする |
-
-ヘッダには commit、未コミット変更の有無、物理コア数、ファイルシステム種別、カーネルを出力します。後から「どの条件の数字か」を復元できるようにするためです。
-
-HyperDU の変種間（rayon-par など）の比較には `scripts/bench/run.sh` を使います。
-
-```
-scripts/bench/run.sh --root /path/to/dir
-WITH_RAYON=1 scripts/bench/run.sh --root /path/to/dir
-```
-
-回帰基準（目安）
-
-### ランタイムチューニング（任意・上級者）
-
-- `hyperdu … --tune` でアダプティブチューナを有効化（dir_yield/実行スレッド数を動的調整）
-- スレッドは `active_threads` を動的に制御（[1, threads] 範囲）
-  - I/O待ちやSQE失敗が多い→縮退
-  - throughput改善が続く→段階的に増加
-```
-
-## 🤝 コントリビューション
-
-プルリクエストを歓迎します！大きな変更の場合は、まず Issue を開いて変更内容について議論してください。
-
-1. フォーク
-2. フィーチャーブランチ作成 (`git checkout -b feature/AmazingFeature`)
-3. 変更をコミット (`git commit -m 'Add some AmazingFeature'`)
-4. ブランチをプッシュ (`git push origin feature/AmazingFeature`)
-5. プルリクエストを開く
-
-## 📝 ライセンス
-
-このプロジェクトは MIT ライセンスの下でライセンスされています - 詳細は [LICENSE](LICENSE) ファイルを参照してください。
-
-## 🙏 謝辞
-
-- [ripgrep](https://github.com/BurntSushi/ripgrep) - 高速検索の実装参考
-- [fd](https://github.com/sharkdp/fd) - 並列ファイルシステム走査の参考
-- [dust](https://github.com/bootandy/dust) - UIデザインの参考
-
-## 📈 実装状況と今後の計画
-
-### 今後の計画
-- [ ] Linux/macOS での動作確認とテスト
-- [ ] 各プラットフォームでのベンチマーク測定
-- [ ] 機械学習によるサイズ推定の実装
-- [ ] より詳細なドキュメント作成
-
-## ⚠️ 既知の問題と制限事項
-
-### 動作環境
-- **Windows**: 検証済み（NTFS、CI あり）
-- **Linux**: 検証済み（Amazon Linux 2023 / xfs、WSL2 / ext4、CI あり）
-- **macOS**: 実機未検証（ビルドは可能）
-
-### その他の問題
-- WSL環境: `/mnt/*` (NTFS) でビルド時に一時ディレクトリ削除エラーが出る場合があります。Linux側にリポジトリを配置するか、`CARGO_TARGET_DIR` を設定してください
-- シンボリックリンク: デフォルトでは追跡しません。`--follow-links`で有効化できますが、循環参照に注意してください
+[Web site](https://automationjp.github.io/HyperDiskUsage/) · [English](https://automationjp.github.io/HyperDiskUsage/en/) · [Benchmarks](docs/benchmarks.md) · [Agent Plugin](plugin/README.md)
 
 ---
 
-**HyperDU** - ディスク使用量分析を、より速く、より効率的に。
+## Quick start
 
+CLI は crates.io から導入できます。
 
-### Explicit Linux snapshots (experimental)
+```bash
+cargo install hyperdu-cli --version 0.5.0-beta.2
+hyperdu . --top 20
+```
 
-```sh
+クレート名は `hyperdu-cli` ですが、インストールされるコマンド名は **`hyperdu`** です。
+
+よく使う例:
+
+```bash
+# カレントディレクトリを解析
+hyperdu .
+
+# 大きい項目を上位 20 件表示
+hyperdu /path/to/data --top 20
+
+# JSON へ出力
+hyperdu /path/to/data --json result.json
+
+# GNU du 互換モード
+hyperdu --compat gnu -sh /var/log
+```
+
+全オプションは `hyperdu --help` で確認できます。
+
+## Performance
+
+HyperDU は、単に `du` を Rust で書き直したものではありません。OS ごとのディレクトリ列挙 API、並列走査、物理サイズ取得方法まで含めて走査経路を最適化しています。
+
+同一マシン（Ryzen 9 3900X / NVMe SSD）で 2026-09-07 に測定した代表値です。
+
+| Platform | Dataset | HyperDU | Comparison | Result |
+|---|---:|---:|---:|---:|
+| Windows | 101,368 files / 2.96 GB | **251 ms** | robocopy `/L /S`: 14,362 ms | **57×** |
+| Windows | 101,368 files / 2.96 GB | **251 ms** | GNU du 8.32 (MSYS2): 12,871 ms | **51×** |
+| Linux (WSL2/ext4) | 712,374 files | **191 ms** | du (uutils 0.8.0): 2,900 ms | **15×** |
+
+ここでの倍率は「比較対象の実行時間 ÷ HyperDU」です。
+
+走査量が一致していることを確認して測定しています。Windows の比較では HyperDU と robocopy のファイル数 101,368、バイト数 2,956,477,017 が一致しています。
+
+ただし、**57× や 15× がすべての環境で出るわけではありません**。ツリー形状、ページキャッシュ、物理コア数、ファイルシステム、HDD/NVMe、ネットワークストレージなどで差は変わります。より差が小さい結果を含む測定条件・warm/cold benchmark・再現手順は [docs/benchmarks.md](docs/benchmarks.md) にまとめています。
+
+### Why it is fast
+
+| Platform | Main path | Optimization |
+|---|---|---|
+| Linux | `getdents64` + `statx` | ディレクトリエントリをまとめて取得し、並列に metadata を集計 |
+| Windows | `NtQueryDirectoryFile` / `FileIdFullDirectoryInformation` | 名前・サイズ・allocation size・file ID をバッチで取得 |
+| macOS | `getattrlistbulk` | metadata をバルク取得 |
+
+加えて、コアスキャナではワーカーごとの LIFO deque と work stealing を使って動的に負荷分散します。巨大ディレクトリの処理継続ジョブも優先キューへ回し、ワーカーが一時的な queue empty を終了と誤認しないよう in-flight job を追跡します。
+
+Windows では `--mft` を指定し、管理者権限で NTFS volume root を走査できる場合、`$MFT` 直接読み取り経路も利用できます。必要な DATA extent を安全に解決できない場合は directory enumeration へ fallback します。
+
+## What HyperDU provides
+
+### Fast disk analysis
+
+- 論理サイズ / 物理 allocation size の集計
+- hardlink の重複排除
+- マルチスレッド走査
+- filesystem ごとの自動戦略
+- 除外パターン、深さ、最小ファイルサイズ指定
+- JSON / CSV 出力
+- basic / deep classification
+- progress / runtime tuning
+
+### GNU `du` compatibility mode
+
+既存スクリプトから移行しやすいよう、GNU `du` 互換モードを提供しています。
+
+```bash
+hyperdu --compat gnu -sh /var/log
+hyperdu --compat gnu -ak /home --max-depth=2
+hyperdu --compat gnu -b --time /usr/share
+```
+
+必要であれば alias で段階的に置き換えられます。
+
+```bash
+alias du='hyperdu --compat gnu'
+```
+
+互換性や出力差分は継続的にテストしていますが、GNU coreutils の全挙動を無条件に完全再現することを保証するものではありません。
+
+### Structured output
+
+人が読む CLI 出力だけでなく、後段処理しやすい JSON / CSV を生成できます。
+
+```bash
+hyperdu /srv/data --json usage.json
+hyperdu /srv/data --csv usage.csv
+```
+
+分類結果も別レポートとして出力できます。詳細は `hyperdu --help` を参照してください。
+
+## AI agents: MCP / Skill / Plugin
+
+HyperDU は、人間が端末で使うだけでなく、Claude や Codex などの AI エージェントがディスク逼迫を調査できるように設計しています。
+
+提供する面は独立しています。
+
+| Interface | Purpose | MCP required? |
+|---|---|---|
+| MCP server | typed arguments / structured results | Yes |
+| Agent Skill | `hyperdu` CLI を使った triage workflow | No |
+| Agent Plugin | MCP + Skill をまとめて配布 | Optional |
+
+MCP server は次の 3 ツールを公開します。
+
+| Tool | Question it answers |
+|---|---|
+| `list_volumes` | どのドライブ / volume が逼迫しているか |
+| `scan_path` | その中で何が大きいか |
+| `find_reclaimable` | そのうち再生成可能な候補は何か |
+
+**削除ツールは意図的に提供していません。** 誤った容量報告はやり直せますが、エージェントによる誤削除は取り返せないためです。
+
+`find_reclaimable` も名前だけで `target/` などを削除候補と判定しません。たとえば Rust の `target/` と判断するには、周辺の `Cargo.toml` など再生成可能性を裏付ける context を確認します。
+
+### MCP setup
+
+MCP server は crates.io から導入できます。`rmcp` の要件により Rust 1.88 以上が必要です。
+
+```bash
+cargo install hyperdu-mcp --version 0.5.0-beta.2
+
+claude mcp add --transport stdio hyperdu -- hyperdu-mcp
+# Codex:
+codex mcp add hyperdu -- hyperdu-mcp
+```
+
+Agent Skill / Plugin のセットアップは [plugin/README.md](plugin/README.md) を参照してください。
+
+## GUI
+
+`hyperdu-gui` は `egui` / `eframe` ベースのデスクトップ UI です。
+
+主な機能:
+
+- リアルタイムスキャン表示
+- インタラクティブな tree view
+- ディレクトリの drill-down
+- files/s など throughput の表示
+- 結果 export
+
+```bash
+cargo install hyperdu-gui --version 0.5.0-beta.2
+hyperdu-gui
+```
+
+## Installation
+
+### crates.io — recommended
+
+現在利用できる正式な配布経路は crates.io です。0.5.0-beta.2 は CLI / Core / GUI / MCP の各 crate が公開済みです。
+
+```bash
+# CLI (Rust 1.75+)
+cargo install hyperdu-cli --version 0.5.0-beta.2
+
+# GUI (Rust 1.75+)
+cargo install hyperdu-gui --version 0.5.0-beta.2
+
+# MCP server (Rust 1.88+)
+cargo install hyperdu-mcp --version 0.5.0-beta.2
+```
+
+プレリリースのため、現時点ではバージョンを明示するのが確実です。
+
+### From source
+
+```bash
+git clone https://github.com/automationjp/HyperDiskUsage.git
+cd HyperDiskUsage
+
+cargo install --path hyperdu-cli
+cargo install --path hyperdu-gui
+cargo install --path hyperdu-mcp
+```
+
+最高性能を確認したい場合は、ローカル CPU 向けに release build できます。
+
+```bash
+RUSTFLAGS="-C target-cpu=native" cargo build --release -p hyperdu-cli
+```
+
+### Other distribution channels — preparing
+
+以下は **まだ利用できません**。README から存在しない download URL へ誘導しないため、公開前の release asset 直リンクは掲載していません。
+
+- GitHub Releases: public release はまだありません
+- winget: manifest submission 前
+- scoop: bucket registration 前
+- deb / rpm / prebuilt assets: release workflow で生成し、public release 後に利用可能になる予定です
+
+現時点では上の crates.io 経路を利用してください。
+
+## Platform status
+
+| Platform | Status | Notes |
+|---|---|---|
+| Windows | **Tested** | NTFS、CI、native directory enumeration、optional MFT path |
+| Linux | **Tested** | Amazon Linux 2023 / XFS、WSL2 / ext4、CI |
+| macOS | Build supported / **not hardware-tested** | `getattrlistbulk` implementationあり、実機検証は未完了 |
+
+Minimum Rust versions:
+
+- `hyperdu-core`, `hyperdu-cli`, `hyperdu-gui`: **Rust 1.75+**
+- `hyperdu-mcp`: **Rust 1.88+** (`rmcp` requirement)
+
+### Filesystem notes
+
+Linux では filesystem に応じて strategy を調整します。たとえば ext4/XFS/ZFS、Btrfs、DrvFS、NFS/SMB/SSHFS/9p/FUSE では physical size や prefetch、buffer size、推奨 thread count の扱いが異なります。
+
+Windows の標準経路は `NtQueryDirectoryFile` です。`HYPERDU_WIN_USE_NTQUERY=0` で `FindFirstFileExW` fallback に切り替えられます。`\\?\` path prefix を使うため、long path も扱います。
+
+## Experimental: persisted Linux snapshots
+
+Linux では、明示的に更新する directory snapshot を実験的に提供しています。
+
+```bash
 mkdir -p "$HOME/.cache/hyperdu"
 hyperdu index refresh /srv/data --database "$HOME/.cache/hyperdu/data.idx"
 hyperdu index show /srv/data --database "$HOME/.cache/hyperdu/data.idx"
 ```
 
-`refresh` runs the existing physical-size scanner and atomically replaces a directory-level
-snapshot. `show` loads saved totals without walking the target tree. Both emit JSON with
-`physical_bytes`, `files`, `directory_count`, `freshness: "stale"` and `monitoring: false`.
-There is no watcher or automatic refresh. Changes are visible only after another `refresh`.
-A snapshot is not an atomic filesystem view, even immediately after scanning.
+これは watcher ではありません。`show` は tree を再走査せず保存値を返し、freshness は常に `stale` と明示します。
 
-The database parent must already exist, and the database must be a regular file outside
-ROOT (not a symlink). Consequently `/` is not a supported snapshot root in this mode.
-Use a separate database for each tree. The mounted device/inode root identity must match;
-rebuild explicitly after remounts, restores or root replacement. An inode can be reused,
-so this identity is a consistency check, not a freshness guarantee. Cancellation, scan
-errors and unrepresentable bind-mount aliases prevent replacement of the previous file.
-Loading costs O(indexed directories), not O(files); after loading, the root lookup is O(1).
-`index` is a subcommand; use `./index` or `-- index` to scan a directory literally named
-`index`. Normal scan options do not apply to these fixed-semantics snapshot commands.
+DB 配置制約、root identity、failure semantics、計算量、watcher との境界は [docs/index-snapshots.md](docs/index-snapshots.md) に分離しました。
 
-For MFT scans, ordinary-file DATA extensions now use stream names and validated record
-references. Unresolved required DATA extents cause a fallback to directory enumeration.
-Named streams (including WOF) remain diagnostic only, not blanket additions to physical
-usage. Live-volume parity and an inotify watcher remain separate acceptance gates; see
-[implementation boundaries](docs/design/issue-16-41-implementation.md).
+## Benchmarking
+
+GNU `du` との比較は `scripts/bench/vs_du.sh` を使ってください。
+
+```bash
+# warm benchmark
+scripts/bench/vs_du.sh /path/to/tree
+
+# cold benchmark (drop_caches のため root/sudo が必要)
+scripts/bench/vs_du.sh --cold /path/to/tree1 /path/to/tree2
+```
+
+この harness は、性能数値が不正に良く見える代表的な失敗を検出して停止します。
+
+- 古い binary を測っている
+- HyperDU と比較対象で走査ファイル集合が違う
+- cold measurement を最小値だけで評価し、storage burst を拾っている
+
+benchmark header には commit、dirty state、physical core count、filesystem、kernel などを残し、後から測定条件を復元できるようにしています。
+
+詳細な結果と方法論は [docs/benchmarks.md](docs/benchmarks.md) を参照してください。
+
+## Architecture
+
+```text
+HyperDiskUsage/
+├── hyperdu-core/     # scanning engine / platform-specific fast paths
+├── hyperdu-cli/      # `hyperdu` command
+├── hyperdu-gui/      # desktop GUI
+├── hyperdu-mcp/      # MCP server for AI agents
+├── plugin/           # Agent Skill / Plugin
+├── docs/             # benchmarks and design notes
+├── site/             # bilingual project web site
+└── scripts/          # benchmark, packaging, lint, development tools
+```
+
+コアと interface を分離しているため、CLI / GUI / MCP は同じ scanner semantics を共有します。
+
+## Development
+
+```bash
+# fast compile check
+cargo check --workspace
+
+# tests
+cargo test --workspace
+
+# formatting
+cargo fmt --check
+
+# lint
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+performance path を変更する PR では、通常の unit/integration test に加えて benchmark の比較条件と regression の有無も確認してください。
+
+大きな変更は先に Issue で設計・受入条件を合わせることを推奨します。GUI変更では screenshot/GIF、scanner変更では risk / rollback と benchmark evidence があるとレビューしやすくなります。
+
+## Documentation
+
+- [Benchmark methodology and results](docs/benchmarks.md)
+- [Linux persisted snapshots](docs/index-snapshots.md)
+- [MFT parity verification](docs/design/mft-parity-verification.md)
+- [Issue #16 / #41 implementation boundaries](docs/design/issue-16-41-implementation.md)
+- [Agent Plugin / Skill](plugin/README.md)
+- [Project web site (日本語)](https://automationjp.github.io/HyperDiskUsage/)
+- [Project web site (English)](https://automationjp.github.io/HyperDiskUsage/en/)
+
+## Known limitations
+
+- ベータ版です。CLI option、MCP tool schema、出力形式は変更される可能性があります。
+- macOS は build path はありますが、実機での性能・互換性検証はまだ完了していません。
+- WSL の `/mnt/*` 上では Rust build 時の temporary directory cleanup が不安定になる場合があります。Linux filesystem 側へ checkout するか `CARGO_TARGET_DIR` を変更してください。
+- symbolic link は既定では追跡しません。`--follow-links` を有効化する場合は cycle に注意してください。
+- network filesystem や HDD では I/O latency が支配的になり、CPU 並列化による差は小さくなる場合があります。
+
+## License
+
+[MIT License](LICENSE)
+
+## Acknowledgements
+
+実装・設計の参考として、特に次のプロジェクトから多くを学んでいます。
+
+- [ripgrep](https://github.com/BurntSushi/ripgrep) — 高速な filesystem / search implementation
+- [fd](https://github.com/sharkdp/fd) — parallel filesystem traversal
+- [dust](https://github.com/bootandy/dust) — disk usage UX
+
+---
+
+**HyperDU — fast disk analysis for humans and agents.**

--- a/README.md
+++ b/README.md
@@ -194,8 +194,13 @@ cargo install hyperdu-mcp --version 0.5.0-beta.2
 git clone https://github.com/automationjp/HyperDiskUsage.git
 cd HyperDiskUsage
 
+# CLI (Rust 1.75+)
 cargo install --path hyperdu-cli
+
+# GUI (Rust 1.75+)
 cargo install --path hyperdu-gui
+
+# MCP server (Rust 1.88+)
 cargo install --path hyperdu-mcp
 ```
 

--- a/docs/index-snapshots.md
+++ b/docs/index-snapshots.md
@@ -1,0 +1,92 @@
+# Linux directory snapshots (experimental)
+
+HyperDU の Linux 向け `index` サブコマンドは、ディレクトリ単位の走査結果を明示的に保存し、次回はファイルツリーを再走査せずに集計値を読み出すための実験的機能です。
+
+> この機能は watcher ではありません。自動更新や常駐監視は行わず、保存値は常に `stale` として扱います。
+
+## Quick start
+
+```sh
+mkdir -p "$HOME/.cache/hyperdu"
+hyperdu index refresh /srv/data --database "$HOME/.cache/hyperdu/data.idx"
+hyperdu index show /srv/data --database "$HOME/.cache/hyperdu/data.idx"
+```
+
+`refresh` は既存の physical-size scanner を実行し、ディレクトリ単位の snapshot をアトミックに置き換えます。`show` は保存済み snapshot を読み込み、対象ツリーを再走査せずに結果を返します。
+
+両コマンドの JSON 出力には、少なくとも次の情報が含まれます。
+
+- `physical_bytes`
+- `files`
+- `directory_count`
+- `freshness: "stale"`
+- `monitoring: false`
+
+## Freshness semantics
+
+snapshot はファイルシステムの atomic snapshot ではありません。`refresh` 完了直後であっても、走査中に対象ツリーが変更される可能性があります。
+
+また、`show` は保存済みデータだけを読みます。新しいファイルや削除されたファイルは、次に `refresh` するまで反映されません。そのため HyperDU は snapshot を常に `stale` と明示します。
+
+## Database constraints
+
+- database の親ディレクトリは事前に存在している必要があります。
+- database は通常ファイルでなければならず、symlink は拒否します。
+- database は scan root の外側に置く必要があります。
+- この制約により `/` は snapshot root として使用できません。
+- 1つの database を複数 tree で共有せず、tree ごとに別ファイルを使用してください。
+
+## Root identity
+
+保存時と読み込み時で、mount された root の device/inode identity が一致している必要があります。
+
+remount、restore、root replacement などで identity が変わった場合は、明示的に `refresh` して snapshot を再構築してください。
+
+inode は再利用される可能性があるため、この identity check は consistency check であり freshness guarantee ではありません。
+
+## Failure semantics
+
+次の場合、既存 snapshot を不完全な結果で置き換えません。
+
+- cancellation
+- scan error
+- 表現できない bind-mount alias
+- root identity を安全に確定できない場合
+
+不完全な結果を「成功した snapshot」として保存しないことを優先しています。
+
+## Cost model
+
+`show` の読み込みコストは **O(indexed directories)** です。ファイル数そのものには比例しません。読み込み後の root lookup は O(1) です。
+
+このため、非常に多数のファイルを含み、ディレクトリ数が相対的に少ない tree では、毎回のフルスキャンより大幅に軽い問い合わせが可能です。
+
+## CLI parsing note
+
+`index` は予約されたサブコマンドです。`index` という名前のディレクトリを通常スキャンしたい場合は、次のように明示してください。
+
+```sh
+hyperdu ./index
+# または
+hyperdu -- index
+```
+
+通常スキャン用オプションは、固定 semantics を持つ `index refresh` / `index show` には適用されません。
+
+## Relationship to watchers
+
+現在の snapshot 機能には、次のものは含まれません。
+
+- inotify watcher
+- background daemon
+- automatic refresh
+- overflow recovery
+- watch budget policy
+
+これらは別の受入条件として扱っています。実装境界は [Issue #16 / #41 implementation notes](design/issue-16-41-implementation.md) を参照してください。
+
+## Windows MFT note
+
+snapshot 実装とは別に、Windows の MFT scan では ordinary-file DATA extension の stream name と validated record reference を使用します。必須 DATA extent を解決できない場合は directory enumeration に fallback します。
+
+named stream（WOF を含む）は診断情報として扱い、physical usage に無条件で加算しません。live-volume parity は別の acceptance gate です。詳細は [MFT parity verification](design/mft-parity-verification.md) と [Issue #16 / #41 implementation notes](design/issue-16-41-implementation.md) を参照してください。


### PR DESCRIPTION
## 概要

README を「機能の全量説明」から「初見ユーザー向けのランディングページ」へ再設計します。

- 冒頭に Quick start と代表 benchmark を集約
- Windows 57x / Linux 15x の測定値を、条件・注意書きとセットで提示
- OS 別 fast path (`getdents64` + `statx`, `NtQueryDirectoryFile`, `getattrlistbulk`) を短く整理
- CLI / GUI / MCP / Agent Skill / Plugin の導線を分離
- crates.io を現在利用可能な正式配布経路として明確化
- CLI/Core/GUI/MCP 0.5.0-beta.2 公開済みの最新 main (#59) を反映
- Rust MSRV を CLI/Core/GUI=1.75+, MCP=1.88+ と明示
- GNU `du` 互換を「全挙動完全互換」と誤読されない表現へ修正
- 重複していた performance 節、全 CLI option 転記、未公開 release asset 直リンクを削減
- README 末尾に混在していた Linux persisted snapshot の詳細仕様を `docs/index-snapshots.md` へ分離
- 古い「Linux 未検証」roadmap と現状の矛盾を解消

## 変更ファイル

- `README.md`
- `docs/index-snapshots.md`

## 検証

- 最新 `main` (`1bccbb3`) へ載せ直し済み
- `main...docs/readme-refresh`: ahead 2 / behind 0
- README を 3 範囲に分けて再読し、Markdown code fence の対応を確認
- README が参照する `docs/benchmarks.md`, `plugin/README.md`, `docs/index-snapshots.md` の存在を確認
- `--mft` が CLI から `use_mft` に接続されることをソースで再確認
- コード変更なしのため Rust build/test には影響しません

## リスク

ドキュメントのみの変更です。機能・CLI semantics・scanner implementation は変更しません。