### PR TITLE
fix: 初回リリースが成立しない 6 件を release pipeline で修正する

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,73 +70,17 @@ jobs:
             dist/*
             snap/snapcraft.yaml
             packaging/flatpak/org.hyperdu.GUI.yaml
+      # --verbose writes dist/build_*.log. They are useful for debugging a failed
+      # release, so they stay in the actions artifact uploaded above, but the
+      # v0.0.1 draft proved they otherwise ship as public release assets.
+      - name: Drop build logs from release assets
+        run: rm -f dist/*.log
       - name: Create GitHub Release (upload assets)
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: |
-            dist/*
-
-  macos:
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-      - name: Install packagers
-        run: |
-          brew update
-          brew install create-dmg || true
-          cargo install cargo-bundle || true
-      - name: Lint (fmt + clippy)
-        run: bash scripts/lint/run.sh
-      - name: Build DMG / zip (GUI)
-        run: |
-          bash scripts/package/macos_dmg.sh --release
-      - name: Generate Homebrew formula
-        run: bash scripts/package/brew.sh
-      - name: Insert URL/SHA into formula
-        run: |
-          URL_BASE="https://github.com/${GITHUB_REPOSITORY}/releases/download/${GITHUB_REF_NAME}"
-          bash scripts/package/release.sh --targets homebrew --url-base "$URL_BASE" --skip-gui --cpu-flavors generic
-        shell: bash
-      - name: Install GitHub CLI
-        run: brew install gh
-        continue-on-error: true
-      - name: Open PR to Homebrew Tap
-        env:
-          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
-          TAP_REPO: ${{ secrets.HOMEBREW_TAP_REPO }}
-        run: |
-          if [[ -z "${TAP_REPO}" || -z "${GH_TOKEN}" ]]; then
-            echo "::warning::Homebrew Tap secrets not set; skipping PR creation."
-            exit 0
-          fi
-          git config --global user.email "actions@github.com"
-          git config --global user.name "GitHub Actions"
-          gh repo clone "$TAP_REPO" taprepo
-          cd taprepo
-          BR="update-hyperdu-${GITHUB_REF_NAME}"
-          git checkout -b "$BR"
-          mkdir -p Formula
-          cp ../dist/brew/hyperdu.rb Formula/hyperdu.rb
-          git add Formula/hyperdu.rb
-          git commit -m "hyperdu ${GITHUB_REF_NAME}"
-          git push -u origin "$BR"
-          gh pr create -R "$TAP_REPO" -t "hyperdu ${GITHUB_REF_NAME}" -b "Automated formula update" -B main
-        shell: bash
-        continue-on-error: true
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: macos-artifacts
-          path: |
-            dist/*
-      - name: Create GitHub Release (upload assets)
-        uses: softprops/action-gh-release@v2
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
+          draft: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             dist/*
 
@@ -239,7 +183,11 @@ jobs:
           $base = Join-Path 'manifests' ($org.Substring(0,1).ToUpper())
           $dir = Join-Path $base "$org\HyperDU\$ver"
           New-Item -ItemType Directory -Path $dir -Force | Out-Null
-          Copy-Item ..\dist\winget\manifest.yaml (Join-Path $dir "$org.HyperDU.yaml") -Force
+          # winget.ps1 emits the three-file ManifestVersion 1.12.0 set
+          # (version / installer / locale), all named $org.HyperDU*.yaml.
+          # The single manifest.yaml this used to copy has not existed since
+          # that rewrite, so copy whatever the generator actually produced.
+          Copy-Item ..\dist\winget\*.yaml $dir -Force
           git add .
           git commit -m "Add HyperDU $ver"
           git push -u origin $BR
@@ -254,5 +202,23 @@ jobs:
         uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
+          draft: true
+          prerelease: ${{ contains(github.ref_name, '-') }}
           files: |
             dist/*
+
+  # Both build jobs each upload to the same tag as a DRAFT. Without this,
+  # whichever job finished first published the release, so a user could see a
+  # "release" carrying only Linux assets while Windows was still compiling --
+  # and a failing job would leave that partial release public. Publishing once,
+  # here, makes the release atomic: it appears only after both platforms
+  # succeeded. GitHub keeps the pre-release flag set by the upload steps.
+  publish:
+    needs: [linux, windows]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Publish the draft release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release edit "$GITHUB_REF_NAME" --draft=false -R "$GITHUB_REPOSITORY"

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ RUSTFLAGS="-C target-cpu=native" cargo build --release -p hyperdu-cli
 |---|---|---|
 | Windows | **Tested** | NTFS、CI、native directory enumeration、optional MFT path |
 | Linux | **Tested** | Amazon Linux 2023 / XFS、WSL2 / ext4、CI |
-| macOS | Build supported / **not hardware-tested** | `getattrlistbulk` implementationあり、実機検証は未完了 |
+| macOS | CLI: **未検証** / GUI: **ビルド不可** | `getattrlistbulk` implementationあり。GUI は `eframe` が推移的に引く `webbrowser` が macOS でコンパイルできないため、現状ビルドできません。release workflow も macOS を対象外にしています |
 
 Minimum Rust versions:
 

--- a/hyperdu-cli/Cargo.toml
+++ b/hyperdu-cli/Cargo.toml
@@ -66,7 +66,12 @@ depends = "$auto"
 maintainer = "HyperDU Maintainers <maintainers@example.com>"
 extended-description = "Hyper-fast disk usage analyzer CLI."
 maintainer-scripts = "../packaging/deb"
+# An explicit assets list turns OFF cargo-deb's automatic binary inclusion, so the
+# executable has to be listed here too. Without this line the .deb installed the
+# man page, the completions and the docs -- and no `hyperdu` command at all.
+# Same source path as [package.metadata.generate-rpm] below, for the same reason.
 assets = [
+  ["../target/release/hyperdu", "/usr/bin/hyperdu", "755"],
   ["../README.md", "/usr/share/doc/hyperdu/README.md", "644"],
   ["../LICENSE", "/usr/share/doc/hyperdu/LICENSE", "644"],
   ["../packaging/man/hyperdu.1", "/usr/share/man/man1/hyperdu.1", "644"],

--- a/scripts/package/release.ps1
+++ b/scripts/package/release.ps1
@@ -53,7 +53,13 @@ function Build-And-Capture([string]$Package, [string]$Rustflags) {
   $psi.FileName = "cargo"
   $psi.Arguments = "build -p $Package --release --message-format=json"
   $psi.RedirectStandardOutput = $true
-  $psi.RedirectStandardError  = $true
+  # stderr is deliberately NOT redirected. This loop only drains stdout, and it
+  # reads to EOF before WaitForExit; cargo writes its "Compiling ..." progress to
+  # stderr, so on a cold CI build that pipe fills its buffer, cargo blocks on the
+  # write, stdout stops, and both sides wait forever -- the windows job would sit
+  # there until the 6-hour Actions ceiling. Letting stderr inherit the console
+  # also puts cargo's progress straight into the Actions log.
+  $psi.RedirectStandardError  = $false
   $psi.UseShellExecute = $false
   if ($Rustflags) { $psi.EnvironmentVariables["RUSTFLAGS"] = $Rustflags }
   $p = [System.Diagnostics.Process]::Start($psi)
@@ -83,8 +89,9 @@ function Build-And-Capture([string]$Package, [string]$Rustflags) {
   }
   $p.WaitForExit()
   if ($p.ExitCode -ne 0) {
-    $err = $p.StandardError.ReadToEnd()
-    throw "cargo build failed: $err"
+    # No captured stderr to quote any more: it went to the console, where the
+    # Actions log already shows cargo's own diagnostics above this line.
+    throw "cargo build failed for $Package (exit $($p.ExitCode))"
   }
   $last = ($paths | Sort-Object | Select-Object -Last 1)
   if (-not $last) { throw "Failed to capture binary for $Package" }
@@ -92,7 +99,16 @@ function Build-And-Capture([string]$Package, [string]$Rustflags) {
 }
 
 $osTag = 'windows'
-$arch = $env:PROCESSOR_ARCHITECTURE
+# PROCESSOR_ARCHITECTURE says "AMD64"; every other part of the project says
+# "x86_64". Left raw, this produced hyperdu-cli-windows-AMD64-generic.zip while
+# scripts/package/scoop.ps1 built an autoupdate URL pointing at
+# hyperdu-cli-windows-x86_64-generic.zip, and the Linux artifacts from
+# release.sh used x86_64 too. Normalize once, here, before any name is built.
+$arch = switch ($env:PROCESSOR_ARCHITECTURE) {
+  'AMD64' { 'x86_64' }
+  'ARM64' { 'aarch64' }
+  default { "$($env:PROCESSOR_ARCHITECTURE)".ToLower() }
+}
 $Dist = Join-Path $Root 'dist'
 if (Test-Path $Dist) { Remove-Item $Dist -Recurse -Force }
 New-Item -ItemType Directory -Path $Dist | Out-Null


### PR DESCRIPTION
## 背景

タグ `v0.5.0-beta.2` を打つ前に、`release.yml` と packaging スクリプトを 6 観点で監査し、各指摘を反証検証にかけました。生き残った 6 件を修正します。

## 修正

| # | 症状 | 場所 |
|---|---|---|
| 1 | **windows ジョブが 6 時間ハングする** | `scripts/package/release.ps1` |
| 2 | Windows アセット名が `AMD64` になり scoop の URL と食い違う | `scripts/package/release.ps1` |
| 3 | beta が "Latest release" として公開される | `.github/workflows/release.yml` |
| 4 | 3 ジョブが競って部分的なリリースを公開する | `.github/workflows/release.yml` |
| 5 | ビルドログが公開資産になる | `.github/workflows/release.yml` |
| 6 | deb に実行ファイルが入っていない | `hyperdu-cli/Cargo.toml` |

### 1 が最重要

`Build-And-Capture` は stdout/stderr 両方を redirect しながら stdout しか drain せず、stderr は `WaitForExit` の後にしか読みません。cargo は `--message-format=json` でも進捗を stderr に書くため、4KB のパイプバッファが埋まると相互待ちになります。実測で cli 3,051 バイト / 92 行、gui 5,562 バイト / 171 行。

**過去の実行が実証しています**:

| run | windows ジョブ | linux ジョブ |
|---|---|---|
| 18034667027 | 6h00m で強制キャンセル | 約 20 分で成功 |
| 17974390842 | 6h00m で強制キャンセル | 成功 |
| 17967969910 | 4h17m で強制キャンセル | 成功 |

`v0.0.1` Draft に Linux アセットしか無いのはこれが理由でした。

### macos ジョブの削除

`hyperdu-gui` は macOS でコンパイルできません。`eframe 0.32` → `egui-winit` → `webbrowser 1.2.4` が `objc2-app-kit 0.3.1` の unsafe fn を unsafe ブロック外で呼ぶ **E0133 のハードエラー**で、crates.io に修正版がありません。`egui-winit` の `links` feature は固定のため feature で切り離すこともできません。

修正 4 のゲートを入れた以上、macOS が失敗するとリリースが永久に draft のままになるため放置できません。`hyperdu-gui/Cargo.toml` の説明も README も対象を Windows/Linux としており、macOS の配布物は元々案内していません。README の対応表も実態に合わせました。

## 検証（ローカル実測）

- `release.ps1` 実行 → `hyperdu-cli-windows-x86_64-generic.{zip,exe}` が生成、zip の中身は `hyperdu.exe` + `README.md`
- CI の manifest 生成ステップを再現 → scoop の autoupdate URL が実アセット名と一致、winget は 3 ファイル構成を生成
- 生成 zip を展開して実行 → `hyperdu 0.5.0-beta.2`、実スキャン成功
- crates.io 版 `hyperdu-mcp` の MCP 疎通 → `initialize` 応答、3 ツール公開
- `plugin/skills/disk-space-triage/scripts/setup-hyperdu.sh --check` → exit 0