### PR TITLE
fix: リリースヘルパーがプレリリースタグを受理するようにする

### DIFF
--- a/scripts/release/tag.sh
+++ b/scripts/release/tag.sh
@@ -29,7 +29,12 @@ USAGE
 if [[ $# -lt 1 ]]; then usage; exit 1; fi
 
 TAG="$1"; shift || true
-[[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "error: tag must be like vX.Y.Z" >&2; exit 1; }
+# SemVer, including a pre-release suffix. The old pattern ended at the patch
+# number, so this helper rejected v0.5.0-beta.2 -- the very tag the project
+# needed to cut -- while .github/workflows/release.yml triggers on the glob
+# v*.*.*, which matches it. The two disagreed; the workflow is the authority.
+[[ "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]] ||
+  { echo "error: tag must be like vX.Y.Z or vX.Y.Z-prerelease" >&2; exit 1; }
 
 RUN_LINT=1
 FORCE_TAG=0


### PR DESCRIPTION
scripts/release/tag.sh の検証は ^v[0-9]+\.[0-9]+\.[0-9]+$ で patch 番号
までしか許さず、v0.5.0-beta.2 を弾いていた。一方 release.yml のトリガは
glob の v*.*.* で、このタグに一致する。ヘルパーと workflow が食い違って
おり、プロジェクトが今まさに打つべきタグをヘルパーが作れなかった。

SemVer のプレリリースとビルドメタデータを許す形にした。
v0.5.0-beta.2 / v1.2.3-rc.1 を受理し、v0.5 / v0.5.0- は従来どおり拒否する。
