### PR TITLE
perf: build_tree がパスをコピーするのをやめる

### DIFF
--- a/hyperdu-gui/src/ui.rs
+++ b/hyperdu-gui/src/ui.rs
@@ -245,21 +245,30 @@ impl eframe::App for App {
     }
 }
 
+/// Parent -> children, borrowing the map's own keys.
+///
+/// Nothing here owns a path. The previous version allocated two `PathBuf`s per
+/// entry building this index (one for the parent key, one for the child) and a
+/// third per node, which on a 1.48M-entry tree was 4.4M allocations and half
+/// the build time. Each child's `Stat` rides along so neither the comparator
+/// nor the node builder ever hashes a path again.
+type ChildIndex<'a> = HashMap<&'a Path, Vec<(&'a Path, &'a Stat)>>;
+
 fn build_tree(root: &Path, map: &StatMap) -> Node {
-    // Build parent -> children index
-    let mut idx: HashMap<PathBuf, Vec<PathBuf>> = HashMap::new();
-    for p in map.keys() {
+    let mut idx: ChildIndex = HashMap::with_capacity(map.len());
+    for (p, stat) in map.iter() {
         if let Some(parent) = p.parent() {
-            idx.entry(parent.to_path_buf()).or_default().push(p.clone());
+            idx.entry(parent).or_default().push((p.as_path(), stat));
         }
     }
-    // Sort children by physical desc
+    // Sort children by physical desc. The Stat is right here, so this is a
+    // plain integer compare -- no map lookup per element, let alone per
+    // comparison as the original did.
     for v in idx.values_mut() {
-        // cached: the comparison-driven variant re-hashed the path on every
-        // comparison, so a directory with n children paid O(n log n) lookups.
-        v.sort_by_cached_key(|p| std::cmp::Reverse(map.get(p).map(|s| s.physical).unwrap_or(0)));
+        v.sort_unstable_by_key(|(_, stat)| std::cmp::Reverse(stat.physical));
     }
-    fn make_node(p: &Path, idx: &HashMap<PathBuf, Vec<PathBuf>>, map: &StatMap) -> Node {
+
+    fn make_node(p: &Path, stat: Stat, idx: &ChildIndex) -> Node {
         let name = p
             .file_name()
             .and_then(|s| s.to_str())
@@ -267,17 +276,19 @@ fn build_tree(root: &Path, map: &StatMap) -> Node {
             .to_string();
         let mut node = Node {
             name,
-            stat: *map.get(p).unwrap_or(&Stat::default()),
-            children: vec![],
+            stat,
+            children: Vec::new(),
         };
         if let Some(children) = idx.get(p) {
-            for c in children {
-                node.children.push(make_node(c, idx, map));
+            node.children.reserve(children.len());
+            for (child, child_stat) in children {
+                node.children.push(make_node(child, **child_stat, idx));
             }
         }
         node
     }
-    make_node(root, &idx, map)
+
+    make_node(root, map.get(root).copied().unwrap_or_default(), &idx)
 }
 
 /// `chain` is the index path from the root down to `node`, maintained as the


### PR DESCRIPTION
## 背景

[PR #65](https://github.com/automationjp/HyperDiskUsage/pull/65) でツリー構築を UI スレッドから外し、ウィンドウのフリーズは解消しました。ただし構築そのものの時間は残っており、1,484,070 エントリで 6.0 秒かかっていました。

## 原因

コストはハッシュではなく**アロケーション**でした。

- 親インデックス構築: 1 エントリあたり `PathBuf` を 2 つ確保（`parent.to_path_buf()` と `p.clone()`）
- ノード生成: さらに 1 つ

合計で約 440 万回の割り当てです。ハッシャを ahash に替えても差が出なかったことが、ハッシュが律速でないことを裏付けています。

## 変更

中間表現を `HashMap<&Path, Vec<(&Path, &Stat)>>` に変更し、`StatMap` のキーをそのまま借用します。パスを 1 つも所有しません。子の `Stat` を一緒に持たせたので、ソートの比較子もノード生成も `map` を引きません。

`build_tree` のシグネチャと出力の `Node` は変更していません。

## 実測

`F:/github`、1,484,070 エントリ、各 3 回の最小値:

| 実装 | 時間 | 対現行 |
|---|---|---|
| 変更前 | 6,024 ms | 100% |
| **変更後（パス借用）** | **2,862 ms** | **48%** |
| 参考: 上記 + 名前アリーナ | 2,910 ms | 48% |

名前の `String` 割り当ては律速ではなかったため、アリーナ化は複雑さに見合わないと判断し見送りました。

## 検証

- `cargo clippy -p hyperdu-gui --all-targets`: 警告なし
- `cargo fmt --check`: クリーン
- release ビルドを起動 → `Responding=True`