### PR TITLE
fix: --follow-links と --dir-yield-every の併用でファイルを取りこぼす

### DIFF
--- a/hyperdu-core/src/platform/linux_x86_64_impl.rs
+++ b/hyperdu-core/src/platform/linux_x86_64_impl.rs
@@ -43,7 +43,15 @@ pub fn process_dir(ctx: &ScanContext, dctx: &DirContext, map: &mut StatMap) {
             // in which case there is no boundary to enforce.
             let leaves_root_fs =
                 opt.one_file_system && opt.root_fs_id != 0 && dev != opt.root_fs_id;
-            if leaves_root_fs || check_visited_directory(opt, dev, st_cur.st_ino) {
+            // `check_visited_directory` claims the directory as it tests it, so
+            // it must not run for a resume job. A resume is this scan returning
+            // to a directory it already claimed after `dir_yield_every` split
+            // it; asking again finds that first claim, reports "seen", and
+            // everything past the first chunk is dropped without a word. With
+            // `--follow-links --dir-yield-every 5000` a 20k-file directory
+            // reported 5000 files.
+            let already_seen = resume.is_none() && check_visited_directory(opt, dev, st_cur.st_ino);
+            if leaves_root_fs || already_seen {
                 unsafe { libc::close(fd) };
                 return;
             }

--- a/hyperdu-core/tests/yield_resume.rs
+++ b/hyperdu-core/tests/yield_resume.rs
@@ -1,0 +1,98 @@
+//! `dir_yield_every` splits a large directory into resume jobs. Those jobs
+//! re-enter the same directory, which used to collide with the follow-links
+//! bookkeeping and silently drop everything past the first chunk.
+
+use std::{fs, sync::atomic::Ordering};
+
+use hyperdu_core::{scan_directory, Options};
+
+/// Enough entries that the yield thresholds below split the directory several
+/// times. Kept small enough to stay fast on CI.
+const ENTRIES: usize = 300;
+
+fn dir_with_files(n: usize) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    for i in 0..n {
+        fs::File::create(dir.path().join(format!("f{i:05}"))).unwrap();
+    }
+    dir
+}
+
+fn count_files(root: &std::path::Path, follow_links: bool, yield_every: usize) -> u64 {
+    let opt = Options {
+        follow_links,
+        compute_physical: false,
+        ..Default::default()
+    };
+    opt.dir_yield_every.store(yield_every, Ordering::Relaxed);
+    let map = scan_directory(root, &opt).unwrap();
+    map.get(root).map(|s| s.files).unwrap_or(0)
+}
+
+/// Splitting must not change the answer. The visited-directory set claims a
+/// directory as it tests it, so a resume job that re-ran the test found the
+/// claim its own first pass had made, concluded it had already been here, and
+/// returned -- losing every entry after the first chunk. `--follow-links
+/// --dir-yield-every 5000` on a 20k-file directory reported 5000 files.
+#[test]
+fn yield_split_counts_every_file_with_follow_links() {
+    let dir = dir_with_files(ENTRIES);
+    let root = dir.path();
+
+    let baseline = count_files(root, false, 0);
+    assert_eq!(baseline as usize, ENTRIES, "baseline must see every file");
+
+    for yield_every in [0, 32, 100, ENTRIES - 1, ENTRIES, ENTRIES * 2] {
+        let got = count_files(root, true, yield_every);
+        assert_eq!(
+            got as usize, ENTRIES,
+            "follow_links with dir_yield_every={yield_every} saw {got} of {ENTRIES} files"
+        );
+    }
+}
+
+/// The same split without follow-links never regressed, but it is the control:
+/// if this breaks, the cause is the splitting itself rather than the
+/// interaction under test.
+#[test]
+fn yield_split_counts_every_file_without_follow_links() {
+    let dir = dir_with_files(ENTRIES);
+    let root = dir.path();
+
+    for yield_every in [0, 32, 100, ENTRIES * 2] {
+        let got = count_files(root, false, yield_every);
+        assert_eq!(
+            got as usize, ENTRIES,
+            "dir_yield_every={yield_every} saw {got} of {ENTRIES} files"
+        );
+    }
+}
+
+/// A real revisit still has to be caught: following a symlink into a directory
+/// already scanned must count it once, which is what the visited set is for.
+/// Guards against "fixing" the resume case by disabling the check outright.
+#[cfg(unix)]
+#[test]
+fn follow_links_still_dedupes_a_real_revisit() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path().to_path_buf();
+    let real = root.join("real");
+    fs::create_dir(&real).unwrap();
+    for i in 0..ENTRIES {
+        fs::File::create(real.join(format!("f{i:05}"))).unwrap();
+    }
+    std::os::unix::fs::symlink(&real, root.join("link")).unwrap();
+
+    let opt = Options {
+        follow_links: true,
+        compute_physical: false,
+        ..Default::default()
+    };
+    opt.dir_yield_every.store(32, Ordering::Relaxed);
+    let map = scan_directory(&root, &opt).unwrap();
+    let total = map.get(&root).map(|s| s.files).unwrap_or(0);
+    assert_eq!(
+        total as usize, ENTRIES,
+        "the symlinked directory must be counted once, not twice"
+    );
+}


### PR DESCRIPTION
## 症状

Linux x86_64 で `--follow-links` と `--dir-yield-every` を同時に指定すると、**最初のチャンク以降のファイルが黙って消えます**。エラーも警告も出ません。

20000 ファイルの単一ディレクトリでの実測（修正前）:

| 条件 | 検出数 | |
|---|---|---|
| オプション無し | 20000 | ✓ |
| `--dir-yield-every 5000` | 20000 | ✓ |
| `--follow-links` | 20000 | ✓ |
| `--follow-links --dir-yield-every 5000` | **5000** | 75% 欠落 |
| `--follow-links --dir-yield-every 2000` | **2000** | 90% 欠落 |
| `--follow-links --dir-yield-every 10000` | **10000** | 50% 欠落 |

常に「最初の 1 チャンクぶんだけ」が残ります。

## 原因

`common_ops.rs:111-126` の `check_visited_directory` は**検査と登録が 1 つの操作**になっています。

```rust
vset.insert((dev, ino), ()).is_some()
```

同時に同じディレクトリを見つけた 2 ワーカーのどちらか一方だけが進めるようにするための設計で、map への insert が所有権の主張を兼ねています。

`linux_x86_64_impl.rs` はこれを**ディレクトリ入場のたびに**呼びます。`dir_yield_every` がディレクトリを分割すると継続ジョブが積まれ（`lib.rs:398-405`）、そのジョブは同じディレクトリで再入します。このとき `check_visited_directory` は**自分自身が最初のパスで入れた登録**を見つけて「もう来た」と答え、関数は `close` して `return` します。`lseek` で読み位置を戻す処理（66-70 行）はその後ろにあるため到達しません。

`follow_links` が無いときに再現しないのは、`check_visited_directory` が `opt.follow_links` を見て早期 return するためです（`common_ops.rs:112-114`）。

## 修正

継続ジョブでは visited の主張をしません。resume はこのスキャンが既に主張済みのディレクトリへ戻ってきただけで、新規到着ではないためです。

```rust
let already_seen = resume.is_none() && check_visited_directory(opt, dev, st_cur.st_ino);
```

`one_file_system` の境界判定は resume でもそのまま走らせています。こちらは副作用が無く、再確認しても害がありません。

## 他プラットフォーム

`unix_fallback_impl.rs:136` は子エントリを enqueue する前に呼んでおり、ディレクトリ自身の入場時ではないため同じ問題は起きません。`macos_impl.rs:35` も同様です。Windows には `dir_yield_every` の消費者がありません。

## テスト

`hyperdu-core/tests/yield_resume.rs` を追加しました。

| テスト | 内容 |
|---|---|
| `yield_split_counts_every_file_with_follow_links` | `follow_links` 有効で `dir_yield_every` を 0/32/100/299/300/600 と変え、常に 300 件すべてを数えることを検査 |
| `yield_split_counts_every_file_without_follow_links` | 対照群。壊れたら原因は分割そのものだと切り分けられる |
| `follow_links_still_dedupes_a_real_revisit` | symlink 経由の本当の再訪は 1 回だけ数えること。visited 判定を丸ごと無効にする「修正」を弾くガード |

**修正を戻すと 3 件中 2 件が落ちる**ことを確認済みです（`saw 32 of 300 files`）。

## 検証

- Linux: 227 passed / Windows: 230 passed
- `cargo clippy --workspace --all-targets` / `cargo fmt --check`: クリーン
- CLI でも 7 通りの組合せすべてが 20000 を返すことを確認