### PR TITLE
fix: ベンチハーネスの誤検知を直し、ベンチマークを取り直す

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,8 +1,8 @@
 # Benchmark plan
 
-> **Status: remeasurement required**
+> **Status: warm 測定済み (2026-09-08, commit `07dc887`) / cold と XFS は未測定**
 >
-> README / Web site で公開する性能値は現在再計測中です。過去の数値は [old/benchmarks-2026-09-07.md](old/benchmarks-2026-09-07.md) に移動しました。新しい測定が完了するまで、この文書の結果欄は意図的に `TBD` のままにします。
+> Windows/NTFS と Linux/ext4 の warm 測定を [公開用結果](#公開用結果) に記載しました。全 run の raw time、correctness gate の結果、この測定の限界も併記しています。**倍率を引用する前に [この測定の限界](#この測定の限界) を読んでください** — Linux の比較対象は GNU du ではなく uutils で、Linux 側は WSL2 です。cold と XFS の欄は測定するまで `TBD` のままにします。過去の数値は [old/benchmarks-2026-09-07.md](old/benchmarks-2026-09-07.md) にあります。
 
 ## 目的
 
@@ -16,19 +16,60 @@ HyperDU の性能を、比較対象より都合のよい条件だけ選ばずに
 
 ## 公開用結果
 
+測定日 2026-09-08、commit `07dc887`。すべて **warm**、Windows 9 回 / Linux 7 回を
+両ツール交互に実行した **中央値**。全 run の raw time を各表の下に載せています。
+
 ### Windows / NTFS
 
-| Dataset | Cache | Files | HyperDU | robocopy `/L /S` | GNU du / other | Ratio | Commit |
-|---|---|---:|---:|---:|---:|---:|---|
-| TBD | warm | TBD | TBD | TBD | TBD | TBD | TBD |
-| TBD | cold | TBD | TBD | TBD | TBD | TBD | TBD |
+AMD Ryzen 9 3900X (12C/24T)、128 GiB RAM、WD_BLACK SN850X (NVMe SSD)、
+Windows 11 Pro 10.0.26200、NTFS、ベアメタル。
+
+| Dataset | Cache | Files | HyperDU | robocopy `/L /S` | Ratio | Commit |
+|---|---|---:|---:|---:|---:|---|
+| `.cargo/registry` (C:) | warm | 111,025 | 396 ms | 1,823 ms | 4.60x | `07dc887` |
+| `HyperDiskUsage` (F:) | warm | 35,876 | 148 ms | 546 ms | 3.69x | `07dc887` |
+| — | cold | — | 未測定 | 未測定 | — | — |
+
+raw (ms):
+
+```
+registry  hyperdu   341  468  558  574  412  396  299  333  339   min=299  med=396  max=574
+registry  robocopy 1960 1953 1765 2456 1828 1802 1632 1756 1823   min=1632 med=1823 max=2456
+hdu-repo  hyperdu   139  249  304  317  490  143  148  144  132   min=132  med=148  max=490
+hdu-repo  robocopy  432  450  546  663  489  594  628  451  581   min=432  med=546  max=663
+```
 
 ### Linux / ext4
 
+同一マシン上の WSL2 (Ubuntu 26.04 LTS、kernel 6.18.33.2-microsoft-standard-WSL2、
+vCPU 16、90 GiB RAM、ext4 on /dev/sdd)。**ベアメタルの Linux ではありません。**
+
 | Dataset | Cache | Files | HyperDU | `du` | Ratio | Commit |
 |---|---|---:|---:|---:|---:|---|
-| TBD | warm | TBD | TBD | TBD | TBD | TBD |
-| TBD | cold | TBD | TBD | TBD | TBD | TBD |
+| `/usr` | warm | 122,814 | 87 ms | 1,093 ms | 12.56x | `07dc887` |
+| `/var` | warm | 712,519 | 342 ms | 3,975 ms | 11.62x | `07dc887` |
+| wide (500 dir × 40 file) | warm | 20,000 | 23 ms | 113 ms | 4.91x | `07dc887` |
+| **deep (400 段 × 5 file)** | warm | 2,000 | 89 ms | 132 ms | **1.48x** | `07dc887` |
+| **flat (1 dir × 20k file)** | warm | 20,000 | 100 ms | 145 ms | **1.45x** | `07dc887` |
+| — | cold | — | 未測定 | 未測定 | — | — |
+
+raw (ms):
+
+```
+usr   hyperdu   82  101   78   87  118   86   98          min=78   med=87   max=118
+usr   du      1162 1075 1024 1030 1203 1093 1113          min=1024 med=1093 max=1203
+var   hyperdu  296  342  248  297  424  489  448          min=248  med=342  max=489
+var   du      3872 3591 3475 3975 4981 4960 4747          min=3475 med=3975 max=4981
+wide  hyperdu   22   24   23   24   23   24   23          min=22   med=23   max=24
+wide  du       113  115  119  109  102  123  112          min=102  med=113  max=123
+deep  hyperdu   78   85   89   92   84   94   91          min=78   med=89   max=94
+deep  du       130  132  137  128  135  129  140          min=128  med=132  max=140
+flat  hyperdu   96  103   87  117  100  100   98          min=87   med=100  max=117
+flat  du       184  155  162  121  118  145  112          min=112  med=145  max=184
+```
+
+**最も不利なケースは deep (1.48x) と flat (1.45x)** です。並列化の効きにくい形では
+差が 1.5 倍程度まで縮みます。倍率を語るときはこの 2 つを併記してください。
 
 ### Linux / XFS
 
@@ -36,6 +77,57 @@ HyperDU の性能を、比較対象より都合のよい条件だけ選ばずに
 |---|---|---:|---:|---:|---:|---|
 | TBD | warm | TBD | TBD | TBD | TBD | TBD |
 | TBD | cold | TBD | TBD | TBD | TBD | TBD |
+
+## この測定の限界
+
+倍率を引用する前に読んでください。
+
+- **Linux の `du` は GNU coreutils ではなく uutils coreutils 0.8.0** です。Ubuntu 26.04 は
+  uutils を既定の `du` にしており、GNU 版はこのシステムに存在しませんでした
+  (`dpkg -L coreutils` に `du` が無く、diversion も無い)。uutils は一般に GNU より遅い
+  ため、**この比較は HyperDU に有利に働いています**。「GNU du の N 倍」とは言えません。
+- **Linux 側は WSL2** であり、ベアメタルの Linux ではありません。
+- **cold は未測定**です。`vs_du.sh --cold` は `/proc/sys/vm/drop_caches` への書き込みに
+  root を要し、WSL2 ではページキャッシュの挙動もホストと異なります。
+- **XFS は未測定**です。
+- Windows の robocopy は `/XJ` でジャンクションを除外し、HyperDU 側も `-x` で同じ境界を
+  守らせています。
+
+### correctness gate
+
+速度を測る前に、3 者が同じ集合を走査していることを確認しました。
+
+| Check | HyperDU | 比較対象 | Match |
+|---|---:|---:|---|
+| files (`/usr`, `--count-links`) | 122,814 | 122,814 (`find -xdev -type f`) | ✓ |
+| files (`.cargo/registry`) | 111,025 | 111,025 (robocopy `/L /S`) | ✓ |
+| files (`.cargo/registry`) | 111,025 | 111,025 (PowerShell `Get-ChildItem`) | ✓ |
+| dirs (`/usr`) | 13,956 | 13,959 (`find -xdev -type d`) | 差 3 = 後述 |
+| logical bytes (hardlink 検証) | 100,000 | 100,000 (`du -sb`) | ✓ |
+
+差の内訳は次のとおりで、いずれも意図された semantics です。
+
+- **files の 117 件差 (既定時)**: HyperDU は `du` と同じくハードリンクを畳みます。
+  `--count-links` を付けると `find` と完全一致します。100,000 バイトの inode に 4 本
+  リンクを張った検証では `du -sb` = 100,000、HyperDU 既定 = `files=1 log=100000` で
+  一致し、`--count-links` = `files=4 log=400000` が `find` と一致しました。
+- **dirs の 3 件差**: `/usr` 配下のマウントポイントがちょうど 3 個
+  (`/usr/lib/modules/...`、`/usr/lib/wsl/drivers`、`/usr/lib/wsl/lib`)。`find -xdev` は
+  境界のディレクトリ自体を出力し、HyperDU `-x` は除外します。
+
+### 測定中に潰した罠
+
+同じ間違いを繰り返さないための記録です。
+
+- **robocopy が起動していなかった。** Git Bash のパス変換が `/L` を `L:/` に書き換え、
+  robocopy は `ERROR : Invalid Parameter #3` で即座に終了していた。その 100 ms 前後を
+  「robocopy は速い」と読むと「HyperDU が 5 倍遅い」という逆の結論が出る。correctness
+  gate が robocopy のファイル数 0 を示して止めた。`MSYS_NO_PATHCONV=1` が必要。
+- **ハーネスが正しい実装を不一致と誤検知していた。** `find` は全リンクを数え、`du` と
+  HyperDU はどちらも既定でハードリンクを畳む。畳んだ結果同士は一致するのに、畳まない
+  `find` と比べていた。検証側にだけ `--count-links` を付けて解消 (commit `07dc887`)。
+- **`stat -f -c %T` が ext4 を "ext2/ext3" と表示していた。** magic number 0xEF53 を
+  ext2/ext3 と共有するため。`findmnt` を先に引くようにした (同 commit)。
 
 ## 再計測で必ず記録するもの
 

--- a/scripts/bench/vs_du.sh
+++ b/scripts/bench/vs_du.sh
@@ -96,8 +96,18 @@ EOF
 # must not depend on whatever the default happens to be at the time.
 hyperdu() { "$BIN" "$1" --top 1 --exclude "" --one-file-system "${@:2}"; }
 
+# `--count-links` for the check only, because the comparison is against `find`,
+# which prints every link. hyperdu and du both fold hardlinks by default and
+# agree while doing it -- four links to one 100000-byte inode give `du -sb`
+# 100000 and hyperdu log=100000 -- so comparing the folded number against find
+# flags that agreement as a mismatch. /usr made this concrete: 122697 folded
+# against 122814 from find, exactly the 117 the hardlinks account for.
+#
+# Counting links does not change which entries are visited, so this still
+# catches what the check is for: an exclude pattern quietly shrinking the tree.
+# The timed runs below use the defaults, untouched.
 hyperdu_files() {
-  hyperdu "$1" 2>/dev/null | sed -n 's/.*files=\([0-9]*\).*/\1/p' | tail -1
+  hyperdu "$1" --count-links 2>/dev/null | sed -n 's/.*files=\([0-9]*\).*/\1/p' | tail -1
 }
 
 # du and hyperdu must walk the same set, or the comparison measures the filter.
@@ -109,7 +119,7 @@ check_same_workload() {
 error: hyperdu and find disagree on '$tree'; the two tools are not scanning the
        same set, so any timing from this tree is meaningless.
          find    : $find_files files
-         hyperdu : ${hd_files:-<none>} files
+         hyperdu : ${hd_files:-<none>} files  (counted with --count-links)
        Check the active exclude patterns (hyperdu prints them under "Excludes:").
 EOF
   exit 4
@@ -196,7 +206,12 @@ printf '\n'
 for tree in "${TREES[@]}"; do
   files=$(find "$tree" -xdev -type f 2>/dev/null | wc -l)
   dirs=$(find "$tree" -xdev -type d 2>/dev/null | wc -l)
-  fstype=$(stat -f -c %T "$tree" 2>/dev/null || echo '?')
+  # `stat -f` reports the superblock magic, and ext4 shares 0xEF53 with its
+  # predecessors, so it calls an ext4 volume "ext2/ext3". The published tables
+  # separate ext4 from XFS, so the label has to be the real one: ask the mount
+  # table first and keep `stat -f` only for paths findmnt cannot resolve.
+  fstype=$(findmnt -no FSTYPE --target "$tree" 2>/dev/null | head -1)
+  [[ -n "$fstype" ]] || fstype=$(stat -f -c %T "$tree" 2>/dev/null || echo '?')
 
   check_same_workload "$tree" "$files"
 


### PR DESCRIPTION
## ハーネスの修正

`scripts/bench/vs_du.sh` の等価ワークロード検証が `/usr` で停止しました。

```
error: hyperdu and find disagree on '/usr'
  find    : 122814 files
  hyperdu : 122697 files
```

止めたこと自体は設計どおりですが、**判定が間違っていました**。差の 117 件はハードリンクで、`hyperdu` と `du` はどちらも既定でこれを畳みます。畳んだ結果も一致します。

100,000 バイトの inode に 4 本リンクを張った検証:

| ツール | files | logical |
|---|---:|---:|
| `find -type f` | 4 | — |
| `du -sb` | — | **100,000** |
| HyperDU 既定 | 1 | **100,000** ← du と一致 |
| HyperDU `--count-links` | 4 | 400,000 ← find と一致 |

比較対象である `du` と HyperDU は合っており、リンクを畳まない `find` とだけずれます。検証はその `find` と生の件数を比べていたため、**正しく一致している状態を不一致と報告**していました。検証側にだけ `--count-links` を付けます。どのエントリを訪れるかは変わらないので、この検証の目的（exclude パターンが黙ってツリーを縮めていないか）は保たれます。計測される実行は既定のまま触っていません。

あわせて `stat -f -c %T` が ext4 を `ext2/ext3` と表示する問題（magic number 0xEF53 を共有）も直しました。`docs/benchmarks.md` は ext4 と XFS を別の表で公開する構成なので、誤ラベルになります。`findmnt` を先に引きます。

## ベンチマークの取り直し

`docs/benchmarks.md` の `TBD` を埋めました。commit `07dc887`、2026-09-08 測定、両ツール交互実行の中央値です。全 run の raw time も記載しています。

### Windows / NTFS（ベアメタル、robocopy `/L /S` 比）

| Dataset | Files | HyperDU | robocopy | Ratio |
|---|---:|---:|---:|---:|
| `.cargo/registry` | 111,025 | 396 ms | 1,823 ms | 4.60x |
| `HyperDiskUsage` | 35,876 | 148 ms | 546 ms | 3.69x |

### Linux / ext4（WSL2、uutils du 比）

| Dataset | Files | HyperDU | `du` | Ratio |
|---|---:|---:|---:|---:|
| `/usr` | 122,814 | 87 ms | 1,093 ms | 12.56x |
| `/var` | 712,519 | 342 ms | 3,975 ms | 11.62x |
| wide (500 dir × 40 file) | 20,000 | 23 ms | 113 ms | 4.91x |
| **deep (400 段 × 5 file)** | 2,000 | 89 ms | 132 ms | **1.48x** |
| **flat (1 dir × 20k file)** | 20,000 | 100 ms | 145 ms | **1.45x** |

**最も不利なケース（deep / flat）も載せました。** 並列化の効きにくい形では 1.5 倍程度まで縮みます。

## 限界も明記しました

- **Linux の比較対象は GNU coreutils ではなく uutils coreutils 0.8.0** です。Ubuntu 26.04 は uutils を既定の `du` にしており、GNU 版はこのシステムに存在しません。uutils は一般に GNU より遅いため、**この比較は HyperDU に有利に働いています**
- **Linux 側は WSL2** でありベアメタルではありません
- **cold と XFS は未測定**。欄は `TBD` のままです

## correctness gate

速度を測る前に 3 者が同じ集合を走査していることを確認しました。

| Check | HyperDU | 比較対象 | |
|---|---:|---:|---|
| files (`/usr`, `--count-links`) | 122,814 | 122,814 (`find`) | ✓ |
| files (`.cargo/registry`) | 111,025 | 111,025 (robocopy / PowerShell) | ✓ |
| logical bytes (hardlink) | 100,000 | 100,000 (`du -sb`) | ✓ |

## 測定中に潰した罠

**robocopy が起動していませんでした。** Git Bash のパス変換が `/L` を `L:/` に書き換え、robocopy は `ERROR : Invalid Parameter #3` で即座に終了していました。その 100 ms 前後を robocopy の実行時間と読めば「**HyperDU が 5 倍遅い**」という逆の結論が出るところでした。correctness gate が robocopy のファイル数 0 を示して止めています。`MSYS_NO_PATHCONV=1` が必要です。

この経緯も文書に残しました。

## 検証

- `bash scripts/lint/run.sh` 全体が通る
- 修正後 `/usr`、`/var`、wide、deep、flat の 5 ツリーで検証が通り計測が完走
- 文書内アンカーリンクも解決