### PR TITLE
refactor: reclaimable を core に移し、front-end 以外からも使えるようにする

### DIFF
--- a/hyperdu-core/src/lib.rs
+++ b/hyperdu-core/src/lib.rs
@@ -32,6 +32,7 @@ pub mod index;
 pub mod memory_pool;
 mod options; // for OptionsBuilder
 mod platform;
+pub mod reclaimable;
 mod rollup;
 mod scanner; // FileSystemScanner + platform default
 mod scheduler;

--- a/hyperdu-core/src/reclaimable.rs
+++ b/hyperdu-core/src/reclaimable.rs
@@ -14,7 +14,7 @@ use std::{
     time::SystemTime,
 };
 
-use hyperdu_core::{scan_directory, Options};
+use crate::{scan_directory, Options};
 
 /// A directory of regenerable output.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/hyperdu-mcp/src/main.rs
+++ b/hyperdu-mcp/src/main.rs
@@ -20,7 +20,6 @@
 use anyhow::{Context, Result};
 use rmcp::{transport::io::stdio, ServiceExt};
 
-mod reclaimable;
 mod server;
 
 #[tokio::main]

--- a/hyperdu-mcp/src/server.rs
+++ b/hyperdu-mcp/src/server.rs
@@ -262,7 +262,7 @@ impl HyperDuServer {
         let max_depth = params.max_depth;
 
         let found = run_blocking(move || {
-            crate::reclaimable::find(&search_root, min_size, unused_for_days, max_depth)
+            hyperdu_core::reclaimable::find(&search_root, min_size, unused_for_days, max_depth)
         })
         .await?;
 


### PR DESCRIPTION
`hyperdu-mcp/src/reclaimable.rs`（464 行）を `hyperdu-core` に移します。

## これは MCP の都合を含んでいませんでした

import は `std` と `hyperdu_core::{scan_directory, Options}` だけで、**rmcp も serde も schemars も出てきません**。`Candidate` も `Kind` も derive は `Debug/Clone/PartialEq/Eq` のみで、JSON への変換は `server.rs` 側にあります。

中身も「どのディレクトリが再生成可能なビルド出力か」を判定して測って並べるドメインロジックで、プロトコルとは無関係です。

| 要素 | 内容 |
|---|---|
| `Kind` | rust-target / node-modules / python-venv / python-cache / gradle-cache |
| `RULES` | `target` が英単語なので、兄弟ファイル（`Cargo.toml` など）の存在まで見て誤検出を防ぐ |
| `collect` / `classify` / `measure` / `newest_mtime` | 走査・判定・測定 |

core には既に対になる `classify` モジュール（ファイル種別）があり、これはその「ディレクトリ種別」版にあたります。

## 移した理由

MCP に閉じ込められているせいで、**CLI にも GUI にも「消せる候補」機能を出せませんでした。** 「インターフェースとコアライブラリの分離にして、取り込んで動かす想定」という方針に対して、ドメインロジックが front-end の 1 つに置かれている状態です。

**依存は増えません。** core が既に持っているものしか使っていません。

## 変更

git がリネームとして認識するため、実質の差分は 3 行です。

| ファイル | 変更 |
|---|---|
| `{hyperdu-mcp → hyperdu-core}/src/reclaimable.rs` | `use hyperdu_core::..` → `use crate::..` |
| `hyperdu-core/src/lib.rs` | `pub mod reclaimable;` を追加 |
| `hyperdu-mcp/src/main.rs` | `mod reclaimable;` を削除 |
| `hyperdu-mcp/src/server.rs` | `crate::reclaimable::find` → `hyperdu_core::reclaimable::find` |

同梱の 16 件のテストもそのまま core に移動します。

## 検証

**MCP は移設後も同じ結果を返します。** `F:/github/HyperDiskUsage` に対して `rust-target` を 13,839 MiB / idle 5 日として 1 件報告し、「このサーバは何も削除しない」という note も付きます。

**core だけを取り込んだ別クレートから使えることも確認しました。** これが移設の目的そのものです。

```rust
use hyperdu_core::reclaimable::find;
let cs = find(&root, 0, None, 6);
```

同じ 1 件が返り、`kind.rebuild_hint()` も `"cargo build"` を返します。

- `cargo clippy --workspace --all-targets`: 警告 0
- `cargo test --workspace`: 246 passed
